### PR TITLE
fix: validate sources value to be string

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -161,6 +161,12 @@ const NPM_PACKAGE_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
 const jiti = createJiti(null, { cache: false, interopDefault: true, requireCache: false, esmResolve: true })
 
 async function resolveConfig (source: string, opts: LoadConfigOptions): Promise<ResolvedConfig> {
+  if (typeof source !== 'string') {
+    // TODO: Remove in next major version
+    // @ts-expect-error deliberately trigger warning in L142-144
+    return {}
+  }
+
   // Custom user resolver
   if (opts.resolve) {
     const res = await opts.resolve(source, opts)

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -137,11 +137,17 @@ async function extendConfig (config, opts: LoadConfigOptions) {
     delete config[key]
   }
   for (const extendSource of extendSources) {
+    if (typeof extendSource !== 'string') {
+      // TODO: Use error in next major versions
+      // eslint-disable-next-line no-console
+      console.warn(`Cannot extend config from \`${JSON.stringify(extendSource)}\` (which should be a string) in ${opts.cwd}`)
+      continue
+    }
     const _config = await resolveConfig(extendSource, opts)
     if (!_config.config) {
       // TODO: Use error in next major versions
       // eslint-disable-next-line no-console
-      console.warn(`Cannot extend config from ${JSON.stringify(extendSource)} in ${opts.cwd}`)
+      console.warn(`Cannot extend config from \`${extendSource}\` in ${opts.cwd}`)
       continue
     }
     await extendConfig(_config.config, { ...opts, cwd: _config.cwd })
@@ -161,12 +167,6 @@ const NPM_PACKAGE_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
 const jiti = createJiti(null, { cache: false, interopDefault: true, requireCache: false, esmResolve: true })
 
 async function resolveConfig (source: string, opts: LoadConfigOptions): Promise<ResolvedConfig> {
-  if (typeof source !== 'string') {
-    // TODO: Remove in next major version
-    // @ts-expect-error deliberately trigger warning in L142-144
-    return {}
-  }
-
   // Custom user resolver
   if (opts.resolve) {
     const res = await opts.resolve(source, opts)

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -141,7 +141,7 @@ async function extendConfig (config, opts: LoadConfigOptions) {
     if (!_config.config) {
       // TODO: Use error in next major versions
       // eslint-disable-next-line no-console
-      console.warn(`Cannot extend config from ${extendSource} in ${opts.cwd}`)
+      console.warn(`Cannot extend config from ${JSON.stringify(extendSource)} in ${opts.cwd}`)
       continue
     }
     await extendConfig(_config.config, { ...opts, cwd: _config.cwd })


### PR DESCRIPTION
Currently using a package that injects an object as `theme` in nuxt.config and is broken since https://github.com/nuxt/framework/pull/7131. Obviously that will need to be fixed in the theme, but in a similar case in future it will be unclear what the issue is because it triggers the following error:

```js
Nuxi 3.0.0-rc.10-27706138.b31405f
Nuxt 3.0.0-rc.10-27706138.b31405f with Nitro 0.5.1-27706249.08ac81b

 ERROR  Cannot start nuxt:  source.startsWith is not a function

  at node_modules/.pnpm/c12@0.2.10/node_modules/c12/dist/index.mjs:174:44
  at Array.some (<anonymous>)
  at resolveConfig (node_modules/.pnpm/c12@0.2.10/node_modules/c12/dist/index.mjs:174:20)
  at extendConfig (node_modules/.pnpm/c12@0.2.10/node_modules/c12/dist/index.mjs:151:27)
  at extendConfig (node_modules/.pnpm/c12@0.2.10/node_modules/c12/dist/index.mjs:156:11)
  at async loadConfig (node_modules/.pnpm/c12@0.2.10/node_modules/c12/dist/index.mjs:114:5)
```

This change makes it warn instead:

```
 WARN  Cannot extend config from {"meta":{"name":"Nuxt Elements","description":"Building blocks for your next application.","author":"NuxtLabs"}} in /private/tmp/studio/node_modules/.pnpm/@nuxt-themes+elements-edge@0.0.1-fdfc0b1/node_modules/@nuxt-themes/elements-edge/theme
```

It would also be equally easy to filter it out at L136 but thought you might prefer the warning for now.