### PR TITLE
fix: overwrite defaults instead of merging them

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -138,7 +138,7 @@ export async function loadConfig<T extends InputConfig=InputConfig> (opts: LoadC
 
   // Apply defaults
   if (opts.defaults) {
-    r.config = defu(r.config, opts.defaults) as T
+    r.config = { ...opts.defaults, ...r.config }
   }
 
   // Return resolved config

--- a/test/fixture/config.ts
+++ b/test/fixture/config.ts
@@ -9,5 +9,6 @@ export default {
   },
   configFile: true,
   overriden: false,
-  array: ['a']
+  array: ['a'],
+  overridenArray: ['a', 'b', 'c']
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -24,7 +24,8 @@ describe('c12', () => {
         overriden: true
       },
       defaults: {
-        defaultConfig: true
+        defaultConfig: true,
+        overridenArray: [1, 2, 3]
       },
       defaultConfig: {
         extends: ['virtual']
@@ -48,6 +49,11 @@ describe('c12', () => {
         "devConfig": true,
         "npmConfig": true,
         "overriden": true,
+        "overridenArray": [
+          "a",
+          "b",
+          "c",
+        ],
         "rcFile": true,
         "testConfig": true,
         "virtual": true,
@@ -75,6 +81,11 @@ describe('c12', () => {
               "c12-npm-test",
             ],
             "overriden": false,
+            "overridenArray": [
+              "a",
+              "b",
+              "c",
+            ],
             "theme": "./theme",
           },
           "configFile": "config",


### PR DESCRIPTION
In my opinion (maybe I am wrong) the `defaults` should act as a fallback for when a given property is not specified, rather than being merged with it.

## The problem

For the following script:

```ts
import { loadConfig } from "c12"

export type MyConfig = {
  prop1: string[]
  prop2: string[]
}

async function loadMyConfig() {
  const { config } = await loadConfig<MyConfig>({
    defaults: {
      prop1: ["1", "2"],
      prop2: ["3", "4"],
    },
  })

  console.log(config)
}

loadMyConfig()
```

And the following config:

```ts
export default {
  prop1: ["a", "b"],
  prop2: ["c", "d"],
}
```

I was expecting to receive this:

```json
{
  "prop1": [ "a", "b" ],
  "prop2": [ "c", "d" ]
}
```

But instead received this

```json
{
  "prop1": [ "a", "b", "1", "2" ],
  "prop2": [ "c", "d", "3", "4" ]
}
```

## The solution

Instead of merging both the accumulated config with the `defaults`, I am spreading the accumulated config over the `defaults`. This way, default properties will keep untouched if they are not present in the accumulated config.