### PR TITLE
feat: load config from `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - RC config support with [unjs/rc9](https://github.com/unjs/rc9)
 - Multiple sources merged with [unjs/defu](https://github.com/unjs/defu)
 - `.env` support with [dotenv](https://www.npmjs.com/package/dotenv)
+- Support reading config from nearest `package.json` file
 - Support extending nested configurations from multiple local or git sources
 
 ## Usage
@@ -34,32 +35,33 @@ Import:
 
 ```js
 // ESM
-import { loadConfig } from 'c12'
+import { loadConfig } from "c12";
 
 // CommonJS
-const { loadConfig } = require('c12')
+const { loadConfig } = require("c12");
 ```
 
 Load configuration:
 
 ```js
 // Get loaded config
-const { config } = await loadConfig({})
+const { config } = await loadConfig({});
 
 // Get resolved config and extended layers
-const { config, configFile, layers } = await loadConfig({})
+const { config, configFile, layers } = await loadConfig({});
 ```
 
 ## Loading priority
 
 c12 merged config sources with [unjs/defu](https://github.com/unjs/defu) by below order:
 
-1. config overrides passed by options
-2. config file in CWD
+1. Config overrides passed by options
+2. Config file in CWD
 3. RC file in CWD
-4. global RC file in user's home directory
-5. default config passed by options
-6. Extended config layers
+4. Global RC file in user's home directory
+5. Config from `package.json`
+6. Default config passed by options
+7. Extended config layers
 
 ## Options
 
@@ -90,6 +92,14 @@ Load RC config from the workspace directory and user's home directory. Only enab
 ### `dotenv`
 
 Loads `.env` file if enabled. It is disabled by default.
+
+### `packageJson`
+
+Loads config from nearest `package.json` file. It is dsisabled by default.
+
+If `true` value is passed, C12 uses `name` field from `package.json`.
+
+You can also pass either a string or an array of strings as value to use those fields.
 
 ### `defaults`
 
@@ -130,31 +140,28 @@ For custom merging strategies, you can directly access each layer with `layers` 
 // config.ts
 export default {
   colors: {
-    primary: 'user_primary'
+    primary: "user_primary",
   },
-  extends: [
-    './theme',
-    './config.dev.ts'
-  ]
-}
+  extends: ["./theme", "./config.dev.ts"],
+};
 ```
 
 ```js
 // config.dev.ts
 export default {
-  dev: true
-}
+  dev: true,
+};
 ```
 
 ```js
 // theme/config.ts
 export default {
-  extends: '../base',
+  extends: "../base",
   colors: {
-    primary: 'theme_primary',
-    secondary: 'theme_secondary'
-  }
-}
+    primary: "theme_primary",
+    secondary: "theme_secondary",
+  },
+};
 ```
 
 ```js
@@ -202,14 +209,12 @@ Layers:
 Made with 💛 Published under [MIT License](./LICENSE).
 
 <!-- Badges -->
+
 [npm-version-src]: https://img.shields.io/npm/v/c12?style=flat-square
 [npm-version-href]: https://npmjs.com/package/c12
-
 [npm-downloads-src]: https://img.shields.io/npm/dm/c12?style=flat-square
 [npm-downloads-href]: https://npmjs.com/package/c12
-
 [github-actions-src]: https://img.shields.io/github/workflow/status/unjs/c12/ci/main?style=flat-square
 [github-actions-href]: https://github.com/unjs/c12/actions?query=workflow%3Aci
-
 [codecov-src]: https://img.shields.io/codecov/c/gh/unjs/c12/main?style=flat-square
 [codecov-href]: https://codecov.io/gh/unjs/c12

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Loads `.env` file if enabled. It is disabled by default.
 
 ### `packageJson`
 
-Loads config from nearest `package.json` file. It is dsisabled by default.
+Loads config from nearest `package.json` file. It is disabled by default.
 
 If `true` value is passed, C12 uses `name` field from `package.json`.
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -173,7 +173,7 @@ export async function loadConfig<T extends InputConfig = InputConfig>(
     },
     { config, configFile: options.configFile, cwd: options.cwd },
     options.rcFile && { config: configRC, configFile: options.rcFile },
-    options.packageJSON && { config: pkgJson, configFile: "package.json" },
+    options.packageJson && { config: pkgJson, configFile: "package.json" },
   ].filter((l) => l && l.config) as ConfigLayer<T>[];
   r.layers = [...baseLayers, ...r.layers];
 

--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "fixture",
+  "config": {
+    "packageJSON": true
+  }
+}

--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -1,6 +1,9 @@
 {
   "name": "fixture",
-  "config": {
+  "c12": {
     "packageJSON": true
+  },
+  "c12-alt": {
+    "packageJSON2": true
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,6 +10,7 @@ describe("c12", () => {
     const { config, layers } = await loadConfig({
       cwd: r("./fixture"),
       dotenv: true,
+      pkgJson: true,
       globalRc: true,
       extend: {
         extendKey: ["theme", "extends"]
@@ -47,6 +48,7 @@ describe("c12", () => {
         "devConfig": true,
         "npmConfig": true,
         "overriden": true,
+        "packageJSON": true,
         "rcFile": true,
         "testConfig": true,
         "virtual": true,
@@ -85,6 +87,12 @@ describe("c12", () => {
             "testConfig": true,
           },
           "configFile": ".configrc",
+        },
+        {
+          "config": {
+            "packageJSON": true,
+          },
+          "configFile": "package.json",
         },
         {
           "config": {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -92,6 +92,13 @@ describe("c12", () => {
         },
         {
           "config": {
+            "packageJSON": true,
+            "packageJSON2": true,
+          },
+          "configFile": "package.json",
+        },
+        {
+          "config": {
             "colors": {
               "primary": "theme_primary",
               "secondary": "theme_secondary",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,7 +11,7 @@ describe("c12", () => {
     const { config, layers } = await loadConfig({
       cwd: r("./fixture"),
       dotenv: true,
-      pkgJson: true,
+      packageJson: ["c12", "c12-alt"],
       globalRc: true,
       extend: {
         extendKey: ["theme", "extends"],
@@ -50,6 +50,7 @@ describe("c12", () => {
         "npmConfig": true,
         "overriden": true,
         "packageJSON": true,
+        "packageJSON2": true,
         "rcFile": true,
         "testConfig": true,
         "virtual": true,
@@ -88,12 +89,6 @@ describe("c12", () => {
             "testConfig": true,
           },
           "configFile": ".configrc",
-        },
-        {
-          "config": {
-            "packageJSON": true,
-          },
-          "configFile": "package.json",
         },
         {
           "config": {


### PR DESCRIPTION
Issue: #29 

The only questions I have is 

1. Do we want to just normalize it to just use the `name` to drive how to load the package.json or do we want to support array of keys in addition of the `name`. The only reason I asked is unbuild supports these keys `unbuild` and `build`. Let me know what you think.

2. If we extend from multiple directories how do we want the `configFile` naming convention to be ?

Thanks 💚 