### PR TITLE
feat: layer meta and source options

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -233,7 +233,7 @@ async function extendConfig(config, options: LoadConfigOptions) {
     const originalExtendSource = extendSource;
     let sourceOptions = {};
     if (extendSource.source) {
-      sourceOptions = extendSource.meta || {};
+      sourceOptions = extendSource.options || {};
       extendSource = extendSource.source;
     }
     if (Array.isArray(extendSource)) {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -223,6 +223,7 @@ async function extendConfig(config, options: LoadConfigOptions) {
     delete config[key];
   }
   for (let extendSource of extendSources) {
+    const originalExtendSource = extendSource;
     let layerMeta = {};
     if (extendSource.source) {
       layerMeta = extendSource.meta || {};
@@ -237,8 +238,10 @@ async function extendConfig(config, options: LoadConfigOptions) {
       // eslint-disable-next-line no-console
       console.warn(
         `Cannot extend config from \`${JSON.stringify(
-          extendSource
-        )}\` (which should be a string or an array) in ${options.cwd}`
+          originalExtendSource
+        )}\` (which should be a string or { source, meta?> } or [source, meta] format) in ${
+          options.cwd
+        }`
       );
       continue;
     }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -23,7 +23,7 @@ export interface C12InputConfig {
   $development?: UserInputConfig;
   $production?: UserInputConfig;
   $env?: Record<string, UserInputConfig>;
-  $layer?: ConfigLayerMeta;
+  $meta?: ConfigLayerMeta;
 }
 
 export interface InputConfig extends C12InputConfig, UserInputConfig {}
@@ -337,9 +337,9 @@ async function resolveConfig(
   }
 
   // Meta
-  if (res.config.$layer) {
-    res.meta = defu(res.meta, res.config.$layer);
-    delete res.config.$layer;
+  if (res.config.$meta) {
+    res.meta = defu(res.meta, res.config.$meta);
+    delete res.config.$meta;
   }
 
   return res;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -245,9 +245,7 @@ async function extendConfig(config, options: LoadConfigOptions) {
       console.warn(
         `Cannot extend config from \`${JSON.stringify(
           originalExtendSource
-        )}\` (which should be a string or { source, meta?> } or [source, meta] format) in ${
-          options.cwd
-        }`
+        )}\` in ${options.cwd}`
       );
       continue;
     }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -17,7 +17,6 @@ export interface ConfigLayerMeta {
 }
 
 export interface C12InputConfig {
-  extends?: string | string[];
   $envName?: string;
   $test?: UserInputConfig;
   $development?: UserInputConfig;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -29,6 +29,7 @@ export interface InputConfig extends C12InputConfig, UserInputConfig {}
 
 export interface SourceOptions {
   meta?: ConfigLayerMeta;
+  overrides?: UserInputConfig;
   [key: string]: any;
 }
 
@@ -343,6 +344,11 @@ async function resolveConfig(
   // Meta
   res.meta = defu(res.sourceOptions.meta, res.config.$meta);
   delete res.config.$meta;
+
+  // Overrides
+  if (res.sourceOptions.overrides) {
+    res.config = defu(res.sourceOptions.overrides, res.config);
+  }
 
   return res;
 }

--- a/test/fixture/base/config.ts
+++ b/test/fixture/base/config.ts
@@ -1,4 +1,8 @@
 export default {
+  $layer: {
+    name: "base",
+    version: "1.0.0",
+  },
   baseConfig: true,
   colors: {
     primary: "base_primary",

--- a/test/fixture/base/config.ts
+++ b/test/fixture/base/config.ts
@@ -1,5 +1,5 @@
 export default {
-  $layer: {
+  $meta: {
     name: "base",
     version: "1.0.0",
   },

--- a/test/fixture/config.ts
+++ b/test/fixture/config.ts
@@ -1,6 +1,6 @@
 export default {
   theme: "./theme",
-  extends: ["c12-npm-test"],
+  extends: [["c12-npm-test", { userMeta: 123 }]],
   $test: {
     extends: ["./config.dev"],
     envConfig: true,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -132,6 +132,8 @@ describe("c12", () => {
           "configFile": "<path>/fixture/theme/config.ts",
           "cwd": "<path>/fixture/theme",
           "meta": {},
+          "source": "config",
+          "sourceOptions": {},
         },
         {
           "config": {
@@ -156,6 +158,8 @@ describe("c12", () => {
             "name": "base",
             "version": "1.0.0",
           },
+          "source": "config",
+          "sourceOptions": {},
         },
         {
           "config": {
@@ -164,6 +168,8 @@ describe("c12", () => {
           "configFile": "<path>/fixture/config.dev.ts",
           "cwd": "<path>/fixture",
           "meta": {},
+          "source": "./config.dev",
+          "sourceOptions": {},
         },
         {
           "config": {
@@ -171,7 +177,9 @@ describe("c12", () => {
           },
           "configFile": "<path>/fixture/node_modules/c12-npm-test/config.ts",
           "cwd": "<path>/fixture/node_modules/c12-npm-test",
-          "meta": {
+          "meta": {},
+          "source": "<path>/fixture/node_modules/c12-npm-test/config.ts",
+          "sourceOptions": {
             "userMeta": 123,
           },
         },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -95,7 +95,12 @@ describe("c12", () => {
             "envConfig": true,
             "extends": [
               "./config.dev",
-              "c12-npm-test",
+              [
+                "c12-npm-test",
+                {
+                  "userMeta": 123,
+                },
+              ],
             ],
             "overriden": false,
             "theme": "./theme",
@@ -126,6 +131,7 @@ describe("c12", () => {
           },
           "configFile": "<path>/fixture/theme/config.ts",
           "cwd": "<path>/fixture/theme",
+          "meta": {},
         },
         {
           "config": {
@@ -146,6 +152,10 @@ describe("c12", () => {
           },
           "configFile": "<path>/fixture/base/config.ts",
           "cwd": "<path>/fixture/base",
+          "meta": {
+            "name": "base",
+            "version": "1.0.0",
+          },
         },
         {
           "config": {
@@ -153,6 +163,7 @@ describe("c12", () => {
           },
           "configFile": "<path>/fixture/config.dev.ts",
           "cwd": "<path>/fixture",
+          "meta": {},
         },
         {
           "config": {
@@ -160,6 +171,9 @@ describe("c12", () => {
           },
           "configFile": "<path>/fixture/node_modules/c12-npm-test/config.ts",
           "cwd": "<path>/fixture/node_modules/c12-npm-test",
+          "meta": {
+            "userMeta": 123,
+          },
         },
         {
           "config": {


### PR DESCRIPTION
A New `$meta` config is supported for each configuration. This is mainly useful in conjunction with extended layers which can provide their metadata (such as name, version, etc).

Secondly, when extending a layer, users can provide custom source options `{ source: 'extend-source', options: {} }` or `source: ['extend-source, { ...options }]`. This is useful for defining options when extending a layer. Passing options such as cloning tokens. 

It is possible to override layer config and meta also using `opts.overrides` and `opts.meta` but it is probably for specific cases, such as multi-app support when we need to override a layer. we might not advocate this in general to users but gives an escape hatch to configure a layer meta itself by the consumer.