### PR TITLE
feat: generic types support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,7 @@
 {
-  "extends": [
-    "eslint-config-unjs"
-  ],
+  "extends": ["eslint-config-unjs"],
   "rules": {
-    "unicorn/prevent-abbreviations": 0
+    "unicorn/prevent-abbreviations": 0,
+    "@typescript-eslint/no-non-null-assertion": 0
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,6 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm build
+      - run: pnpm test:types
       - run: pnpm vitest --coverage
       - uses: codecov/codecov-action@v3

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint:fix": "eslint --ext .ts,.js,.mjs,.cjs . --fix && prettier -w src test",
     "prepack": "unbuild",
     "release": "changelogen --release && npm publish && git push --follow-tags",
-    "test": "vitest run --coverage"
+    "test": "vitest run --coverage && pnpm test:types",
+    "test:types": "tsc --noEmit"
   },
   "dependencies": {
     "defu": "^6.1.2",
@@ -43,6 +44,7 @@
     "changelogen": "^0.5.1",
     "eslint": "^8.36.0",
     "eslint-config-unjs": "^0.1.0",
+    "expect-type": "^0.15.0",
     "prettier": "^2.8.4",
     "typescript": "^4.9.5",
     "unbuild": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ specifiers:
   dotenv: ^16.0.3
   eslint: ^8.36.0
   eslint-config-unjs: ^0.1.0
+  expect-type: ^0.15.0
   giget: ^1.1.2
   jiti: ^1.17.2
   mlly: ^1.2.0
@@ -33,6 +34,7 @@ devDependencies:
   changelogen: 0.5.1
   eslint: 8.36.0
   eslint-config-unjs: 0.1.0_vgl77cfdswitgr47lm5swmv43m
+  expect-type: 0.15.0
   prettier: 2.8.4
   typescript: 4.9.5
   unbuild: 1.1.2
@@ -2083,6 +2085,10 @@ packages:
       onetime: 6.0.0
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
+    dev: true
+
+  /expect-type/0.15.0:
+    resolution: {integrity: sha512-yWnriYB4e8G54M5/fAFj7rCIBiKs1HAACaY13kCz6Ku0dezjS9aMcfcdVK2X8Tv2tEV1BPz/wKfQ7WA4S/d8aA==}
     dev: true
 
   /fast-deep-equal/3.1.3:

--- a/src/dotenv.ts
+++ b/src/dotenv.ts
@@ -65,7 +65,7 @@ export async function setupDotenv(options: DotenvOptions): Promise<Env> {
 export async function loadDotenv(options: DotenvOptions): Promise<Env> {
   const environment = Object.create(null);
 
-  const dotenvFile = resolve(options.cwd, options.fileName);
+  const dotenvFile = resolve(options.cwd, options.fileName!);
 
   if (existsSync(dotenvFile)) {
     const parsed = dotenv.parse(await fsp.readFile(dotenvFile, "utf8"));
@@ -73,7 +73,7 @@ export async function loadDotenv(options: DotenvOptions): Promise<Env> {
   }
 
   // Apply process.env
-  if (!options.env._applied) {
+  if (!options.env?._applied) {
     Object.assign(environment, options.env);
     environment._applied = true;
   }
@@ -97,7 +97,7 @@ function interpolate(
     return source[key] !== undefined ? source[key] : target[key];
   }
 
-  function interpolate(value: unknown, parents: string[] = []) {
+  function interpolate(value: unknown, parents: string[] = []): any {
     if (typeof value !== "string") {
       return value;
     }
@@ -105,17 +105,17 @@ function interpolate(
     return parse(
       // eslint-disable-next-line unicorn/no-array-reduce
       matches.reduce((newValue, match) => {
-        const parts = /(.?)\${?([\w:]+)?}?/g.exec(match);
+        const parts = /(.?)\${?([\w:]+)?}?/g.exec(match) || [];
         const prefix = parts[1];
 
         let value, replacePart: string;
 
         if (prefix === "\\") {
-          replacePart = parts[0];
+          replacePart = parts[0] || "";
           value = replacePart.replace("\\$", "$");
         } else {
           const key = parts[2];
-          replacePart = parts[0].slice(prefix.length);
+          replacePart = (parts[0] || "").slice(prefix.length);
 
           // Avoid recursion
           if (parents.includes(key)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./dotenv";
 export * from "./loader";
+export * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,96 @@
+import type { JITI } from "jiti";
+import type { JITIOptions } from "jiti/dist/types";
+import type { DotenvOptions } from "./dotenv";
+
+export interface ConfigLayerMeta {
+  name?: string;
+  [key: string]: any;
+}
+
+export type UserInputConfig = Record<string, any>;
+
+export interface C12InputConfig<
+  T extends UserInputConfig = UserInputConfig,
+  MT extends ConfigLayerMeta = ConfigLayerMeta
+> {
+  $test?: T;
+  $development?: T;
+  $production?: T;
+  $env?: Record<string, T>;
+  $meta?: MT;
+}
+
+export type InputConfig<
+  T extends UserInputConfig = UserInputConfig,
+  MT extends ConfigLayerMeta = ConfigLayerMeta
+> = C12InputConfig<T, MT> & T;
+
+export interface SourceOptions<
+  T extends UserInputConfig = UserInputConfig,
+  MT extends ConfigLayerMeta = ConfigLayerMeta
+> {
+  meta?: MT;
+  overrides?: T;
+  [key: string]: any;
+}
+
+export interface ConfigLayer<
+  T extends UserInputConfig = UserInputConfig,
+  MT extends ConfigLayerMeta = ConfigLayerMeta
+> {
+  config: T | null;
+  source?: string;
+  sourceOptions?: SourceOptions<T, MT>;
+  meta?: MT;
+  cwd?: string;
+  configFile?: string;
+}
+
+export interface ResolvedConfig<
+  T extends UserInputConfig = UserInputConfig,
+  MT extends ConfigLayerMeta = ConfigLayerMeta
+> extends ConfigLayer<T, MT> {
+  layers?: ConfigLayer<T, MT>[];
+  cwd?: string;
+}
+
+export interface LoadConfigOptions<
+  T extends UserInputConfig = UserInputConfig,
+  MT extends ConfigLayerMeta = ConfigLayerMeta
+> {
+  name?: string;
+  cwd?: string;
+
+  configFile?: string;
+
+  rcFile?: false | string;
+  globalRc?: boolean;
+
+  dotenv?: boolean | DotenvOptions;
+
+  envName?: string | false;
+
+  packageJson?: boolean | string | string[];
+
+  defaults?: T;
+  defaultConfig?: T;
+  overrides?: T;
+
+  resolve?: (
+    id: string,
+    options: LoadConfigOptions<T, MT>
+  ) =>
+    | null
+    | undefined
+    | ResolvedConfig<T, MT>
+    | Promise<ResolvedConfig<T, MT> | undefined | null>;
+
+  jiti?: JITI;
+  jitiOptions?: JITIOptions;
+
+  extend?:
+    | false
+    | {
+        extendKey?: string | string[];
+      };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,3 +94,15 @@ export interface LoadConfigOptions<
         extendKey?: string | string[];
       };
 }
+
+export type DefineConfig<
+  T extends UserInputConfig = UserInputConfig,
+  MT extends ConfigLayerMeta = ConfigLayerMeta
+> = (input: InputConfig<T, MT>) => InputConfig<T, MT>;
+
+export function createDefineConfig<
+  T extends UserInputConfig = UserInputConfig,
+  MT extends ConfigLayerMeta = ConfigLayerMeta
+>(): DefineConfig<T, MT> {
+  return (input: InputConfig<T, MT>) => input;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,13 +2,19 @@ import { fileURLToPath } from "node:url";
 import { expect, it, describe } from "vitest";
 import { loadConfig } from "../src";
 
-const r = (path) => fileURLToPath(new URL(path, import.meta.url));
-const transformPaths = (object) =>
+const r = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+const transformPaths = (object: object) =>
   JSON.parse(JSON.stringify(object).replaceAll(r("."), "<path>/"));
 
 describe("c12", () => {
   it("load fixture config", async () => {
-    const { config, layers } = await loadConfig({
+    type UserConfig = Partial<{
+      virtual: boolean;
+      overriden: boolean;
+      defaultConfig: boolean;
+      extends: string[];
+    }>;
+    const { config, layers } = await loadConfig<UserConfig>({
       cwd: r("./fixture"),
       dotenv: true,
       packageJson: ["c12", "c12-alt"],
@@ -33,7 +39,7 @@ describe("c12", () => {
       },
     });
 
-    expect(transformPaths(config)).toMatchInlineSnapshot(`
+    expect(transformPaths(config!)).toMatchInlineSnapshot(`
       {
         "$env": {
           "test": {
@@ -71,7 +77,7 @@ describe("c12", () => {
       }
     `);
 
-    expect(transformPaths(layers)).toMatchInlineSnapshot(`
+    expect(transformPaths(layers!)).toMatchInlineSnapshot(`
       [
         {
           "config": {
@@ -201,7 +207,7 @@ describe("c12", () => {
       },
     });
 
-    expect(transformPaths(config)).toMatchInlineSnapshot(`
+    expect(transformPaths(config!)).toMatchInlineSnapshot(`
       {
         "$test": {
           "envConfig": true,

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { loadConfig } from "../src";
 
-const r = (path) => fileURLToPath(new URL(path, import.meta.url));
+const r = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 
 async function main() {
   const fixtureDir = r("./fixture");

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf } from "expect-type";
-import { loadConfig, InputConfig } from "../src";
+import { loadConfig, InputConfig, createDefineConfig } from "../src";
 
 interface MyConfig {
   foo: string;
@@ -9,9 +9,9 @@ interface MyMeta {
   metaFoo: string;
 }
 
-type UserConfig = InputConfig<MyConfig, MyMeta>;
+const defineMyConfig = createDefineConfig<MyConfig, MyMeta>();
 
-const userConfig: UserConfig = {
+const userConfig = defineMyConfig({
   foo: "bar",
   $meta: {
     metaFoo: "bar",
@@ -19,7 +19,7 @@ const userConfig: UserConfig = {
   $development: {
     foo: "bar",
   },
-};
+});
 
 expectTypeOf(userConfig.$production!.foo).toEqualTypeOf<string>();
 expectTypeOf(userConfig.$meta!.metaFoo).toEqualTypeOf<string>();

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,31 @@
+import { expectTypeOf } from "expect-type";
+import { loadConfig, InputConfig } from "../src";
+
+interface MyConfig {
+  foo: string;
+}
+
+interface MyMeta {
+  metaFoo: string;
+}
+
+type UserConfig = InputConfig<MyConfig, MyMeta>;
+
+const userConfig: UserConfig = {
+  foo: "bar",
+  $meta: {
+    metaFoo: "bar",
+  },
+  $development: {
+    foo: "bar",
+  },
+};
+
+expectTypeOf(userConfig.$production!.foo).toEqualTypeOf<string>();
+expectTypeOf(userConfig.$meta!.metaFoo).toEqualTypeOf<string>();
+
+async function main() {
+  const config = await loadConfig<MyConfig, MyMeta>({});
+  expectTypeOf(config.config!.foo).toEqualTypeOf<string>();
+  expectTypeOf(config.meta!.metaFoo).toEqualTypeOf<string>();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,9 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true
   },
-  "include": [
-    "src",
-    "test"
-  ]
+  "include": ["src", "test"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
+ Refactor: Enabled strict type checks and CI tests

Support `<T, MT>` generics for all exported types. User config defined with `InputConfig<MyConfig, MyMeta>` can leverage built-in type hints for meta and environments.

New `createDefineConfig` and `DefineConfig` are also exposed for making it easier for frameworks exposing their `defineXConfig` type utils:

```ts
const defineMyConfig = createDefineConfig<MyConfig, MyMeta>();

```