### PR TITLE
fix: use `rm` instead of `rmdir` for recursive remove

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { rmdir } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import { resolve, extname, dirname } from "pathe";
 import createJiti from "jiti";
@@ -241,7 +241,7 @@ async function resolveConfig<
       ? resolve(process.env.XDG_CACHE_HOME, "c12", name)
       : resolve(homedir(), ".cache/c12", name);
     if (existsSync(tmpDir)) {
-      await rmdir(tmpDir, { recursive: true });
+      await rm(tmpDir, { recursive: true });
     }
     const cloned = await downloadTemplate(source, { dir: tmpDir });
     source = cloned.dir;


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19882

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

New versions of node print:

```
 ERROR  (node:11) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
