### PR TITLE
feat(watchConfig): support hmr

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "giget": "^1.1.2",
     "jiti": "^1.18.2",
     "mlly": "^1.2.0",
+    "ohash": "^1.1.0",
     "pathe": "^1.1.0",
     "perfect-debounce": "^0.1.3",
     "pkg-types": "^1.0.2",

--- a/playground/watch.ts
+++ b/playground/watch.ts
@@ -14,13 +14,24 @@ async function main() {
     extend: {
       extendKey: ["theme", "extends"],
     },
-    onChange: ({ config, path, type }) => {
-      console.log("[watcher]", type, path);
+    onWatch: (event) => {
+      console.log("[watcher]", event.type, event.path);
       console.log(config.config);
     },
+    acceptHMR({ oldConfig, newConfig, getDiff }) {
+      const diff = getDiff();
+      if (diff.length === 0) {
+        console.log("No config changed detected!");
+        return true; // No changes!
+      }
+    },
+    onUpdate({ oldConfig, newConfig, getDiff }) {
+      const diff = getDiff();
+      console.log("Config updated:\n" + diff.map((i) => i.toJSON()).join("\n"));
+    },
   });
-  console.log("initial config", config.config, config.layers);
   console.log("watching config files:", config.watchingFiles);
+  console.log("initial config", config.config);
 }
 
 // eslint-disable-next-line unicorn/prefer-top-level-await

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ dependencies:
   mlly:
     specifier: ^1.2.0
     version: 1.2.0
+  ohash:
+    specifier: ^1.1.0
+    version: 1.1.0
   pathe:
     specifier: ^1.1.0
     version: 1.1.0
@@ -2949,6 +2952,10 @@ packages:
       node-fetch-native: 1.1.0
       ufo: 1.1.1
     dev: true
+
+  /ohash@1.1.0:
+    resolution: {integrity: sha512-KNKg5q7wmG6YG46AoWvO2tJoNxcVLuhnn+f0UnoTNuBUpH7tPAOES+R3ptnHw4QpEee4zutsMznAvTZj6eQoLg==}
+    dev: false
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}

--- a/test/fixture/config.ts
+++ b/test/fixture/config.ts
@@ -10,5 +10,7 @@ export default {
   },
   configFile: true,
   overriden: false,
+  // foo: "bar",
+  // x: "123",
   array: ["a"],
 };


### PR DESCRIPTION
Following up #77 

This PR improve hooks with new `acceptHMR` lifecycle hook that allows handling config updates. Built-in `getDiff` uses [ohash.diff](https://github.com/unjs/ohash#diffobj1-obj2-options) internally to compare configs for easy implementation.