### PR TITLE
feat: improve extending github layers

### DIFF
--- a/test/fixture/.gitignore
+++ b/test/fixture/.gitignore
@@ -1,1 +1,2 @@
 !node_modules
+node_modules/.c12

--- a/test/fixture/_github/config.ts
+++ b/test/fixture/_github/config.ts
@@ -1,0 +1,3 @@
+export default {
+  githubLayer: true,
+};

--- a/test/fixture/_github/package.json
+++ b/test/fixture/_github/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "c12-github-layer",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./config.ts"
+  }
+}

--- a/test/fixture/config.ts
+++ b/test/fixture/config.ts
@@ -1,6 +1,6 @@
 export default {
   theme: "./theme",
-  extends: [["c12-npm-test", { userMeta: 123 }]],
+  extends: [["gh:unjs/c12/test/fixture#main", { userMeta: 123 }]],
   $test: {
     extends: ["./config.dev"],
     envConfig: true,

--- a/test/fixture/config.ts
+++ b/test/fixture/config.ts
@@ -1,6 +1,9 @@
 export default {
   theme: "./theme",
-  extends: [["gh:unjs/c12/test/fixture#main", { userMeta: 123 }]],
+  extends: [
+    ["c12-npm-test", { userMeta: 123 }],
+    ["gh:unjs/c12/test/fixture/_github#feat/clone-fixes", { userMeta: 123 }],
+  ],
   $test: {
     extends: ["./config.dev"],
     envConfig: true,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -67,6 +67,7 @@ describe("c12", () => {
         "defaultConfig": true,
         "devConfig": true,
         "envConfig": true,
+        "githubLayer": true,
         "npmConfig": true,
         "overriden": true,
         "packageJSON": true,
@@ -104,6 +105,12 @@ describe("c12", () => {
               "./config.dev",
               [
                 "c12-npm-test",
+                {
+                  "userMeta": 123,
+                },
+              ],
+              [
+                "gh:unjs/c12/test/fixture/_github#feat/clone-fixes",
                 {
                   "userMeta": 123,
                 },
@@ -186,6 +193,18 @@ describe("c12", () => {
           "cwd": "<path>/fixture/node_modules/c12-npm-test",
           "meta": {},
           "source": "<path>/fixture/node_modules/c12-npm-test/config.ts",
+          "sourceOptions": {
+            "userMeta": 123,
+          },
+        },
+        {
+          "config": {
+            "githubLayer": true,
+          },
+          "configFile": "<path>/fixture/node_modules/.c12/gh_unjs_c12_JtzxmAv2Dh/config.ts",
+          "cwd": "<path>/fixture/node_modules/.c12/gh_unjs_c12_JtzxmAv2Dh",
+          "meta": {},
+          "source": "config",
           "sourceOptions": {
             "userMeta": 123,
           },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR improves extending behavior for GitHub layers by preferring to clone to local `node_modules/.c12/{id}`. This way layers can share the same dependencies of the main project.

Other improvements:
 - Cloned layer names are explicitly hashed using ohash. This resolves issues when cloning from same github remote but different directories when it was possible to conflict cache
 - Supported `gh:` shorthand

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
