### PR TITLE
feat: allow setting giget clone options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Custom [unjs/jiti](https://github.com/unjs/jiti) instance used to import configu
 
 Custom [unjs/jiti](https://github.com/unjs/jiti) options to import configuration files.
 
+### `giget`
+
+Options passed to [unjs/giget](https://github.com/unjs/giget) when extending layer from git source.
+
 ### `envName`
 
 Environment name used for [environment specific configuration](#environment-specific-configuration).
@@ -203,6 +207,39 @@ Layers:
  { config: /* base  config */, configFile: /* path/to/base/config.ts  */, cwd: /* path/to/base */ },
  { config: /* dev   config */, configFile: /* path/to/config.dev.ts  */, cwd: /* path/ */ },
 ]
+```
+
+## Extending Config Layer from Remote Sources
+
+You can also extend configuration from remote sources such as npm or github.
+
+In the repo, there should be a `config.ts` (or `config.{name}.ts`) file to be considered as a valid config layer.
+
+**Example:** Extend from a github repository
+
+```js
+// config.ts
+export default {
+  extends: "gh:repo/owner",
+};
+```
+
+**Example:** Extend from a github repository with branch and subpath
+
+```js
+// config.ts
+export default {
+  extends: "gh:repo/owner/test/fixture/_github#main",
+};
+```
+
+**Example:** Extend with custom configuration ([giget](https://github.com/unjs/giget) options)
+
+```js
+// config.ts
+export default {
+  extends: ["gh:repo/owner", { giget: { auth: process.env.GITHUB_TOKEN } }],
+};
 ```
 
 ## Environment-specific configuration

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ export default {
 ```js
 // config.ts
 export default {
-  extends: "gh:repo/owner/test/fixture/_github#main",
+  extends: "gh:repo/owner/theme#dev",
 };
 ```
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -255,7 +255,11 @@ async function resolveConfig<
     if (existsSync(cloneDir)) {
       await rm(cloneDir, { recursive: true });
     }
-    const cloned = await downloadTemplate(source, { dir: cloneDir });
+    const cloned = await downloadTemplate(source, {
+      dir: cloneDir,
+      ...options.giget,
+      ...sourceOptions.giget,
+    });
     source = cloned.dir;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ export interface LoadConfigOptions<
   jiti?: JITI;
   jitiOptions?: JITIOptions;
 
-  giget: DownloadTemplateOptions;
+  giget?: DownloadTemplateOptions;
 
   extend?:
     | false

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { JITI } from "jiti";
 import type { JITIOptions } from "jiti/dist/types";
+import type { DownloadTemplateOptions } from "giget";
 import type { DotenvOptions } from "./dotenv";
 
 export interface ConfigLayerMeta {
@@ -30,6 +31,7 @@ export interface SourceOptions<
   MT extends ConfigLayerMeta = ConfigLayerMeta,
 > {
   meta?: MT;
+  giget?: DownloadTemplateOptions;
   overrides?: T;
   [key: string]: any;
 }
@@ -87,6 +89,8 @@ export interface LoadConfigOptions<
 
   jiti?: JITI;
   jitiOptions?: JITIOptions;
+
+  giget: DownloadTemplateOptions;
 
   extend?:
     | false

--- a/test/fixture/config.ts
+++ b/test/fixture/config.ts
@@ -1,9 +1,14 @@
-export default {
+import { createDefineConfig } from "../../src";
+import type { SourceOptions } from "../../src";
+
+const defineConfig = createDefineConfig();
+
+export default defineConfig({
   theme: "./theme",
   extends: [
-    ["c12-npm-test", { userMeta: 123 }],
-    ["gh:unjs/c12/test/fixture/_github#main", { userMeta: 123 }],
-  ],
+    ["c12-npm-test"],
+    ["gh:unjs/c12/test/fixture/_github#main", { giget: {} }],
+  ] as [string, SourceOptions][] /* TODO: Auto type */,
   $test: {
     extends: ["./config.dev"],
     envConfig: true,
@@ -16,4 +21,4 @@ export default {
   // foo: "bar",
   // x: "123",
   array: ["a"],
-};
+});

--- a/test/fixture/config.ts
+++ b/test/fixture/config.ts
@@ -1,14 +1,9 @@
-import { createDefineConfig } from "../../src";
-import type { SourceOptions } from "../../src";
-
-const defineConfig = createDefineConfig();
-
-export default defineConfig({
+export default {
   theme: "./theme",
   extends: [
     ["c12-npm-test"],
     ["gh:unjs/c12/test/fixture/_github#main", { giget: {} }],
-  ] as [string, SourceOptions][] /* TODO: Auto type */,
+  ],
   $test: {
     extends: ["./config.dev"],
     envConfig: true,
@@ -21,4 +16,4 @@ export default defineConfig({
   // foo: "bar",
   // x: "123",
   array: ["a"],
-});
+};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -105,14 +105,13 @@ describe("c12", () => {
               "./config.dev",
               [
                 "c12-npm-test",
-                {
-                  "userMeta": 123,
-                },
               ],
               [
                 "gh:unjs/c12/test/fixture/_github#main",
                 {
-                  "userMeta": 123,
+                  "giget": {
+                    "registry": "x",
+                  },
                 },
               ],
             ],
@@ -193,9 +192,7 @@ describe("c12", () => {
           "cwd": "<path>/fixture/node_modules/c12-npm-test",
           "meta": {},
           "source": "<path>/fixture/node_modules/c12-npm-test/config.ts",
-          "sourceOptions": {
-            "userMeta": 123,
-          },
+          "sourceOptions": {},
         },
         {
           "config": {
@@ -206,7 +203,9 @@ describe("c12", () => {
           "meta": {},
           "source": "config",
           "sourceOptions": {
-            "userMeta": 123,
+            "giget": {
+              "registry": "x",
+            },
           },
         },
         {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -109,9 +109,7 @@ describe("c12", () => {
               [
                 "gh:unjs/c12/test/fixture/_github#main",
                 {
-                  "giget": {
-                    "registry": "x",
-                  },
+                  "giget": {},
                 },
               ],
             ],
@@ -203,9 +201,7 @@ describe("c12", () => {
           "meta": {},
           "source": "config",
           "sourceOptions": {
-            "giget": {
-              "registry": "x",
-            },
+            "giget": {},
           },
         },
         {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows setting giget cloning options both with top level `loadConfig` and also in each extends layer using layer meta:

```ts
export default defineConfig({
  theme: "./theme",
  extends: [
    ["gh:repo/ownwer", { giget: { auth: process.env.GITHUB_AUTH } }],
  ]
})
```

Also unblocks #51 since once we support this feature in giget, (https://github.com/unjs/giget/issues/6), `giget: { installDependencies: true }` would allow installing layer dependencies!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
