### PR TITLE
fix: clone sub layers into `node_modules/.c12`

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -255,7 +255,10 @@ async function resolveConfig<
 
     const localNodeModules = resolve(options.cwd!, "node_modules");
 
-    if (existsSync(localNodeModules)) {
+    const parentDir = dirname(options.cwd!);
+    if (basename(parentDir) === ".c12") {
+      cloneDir = join(parentDir, cloneName);
+    } else if (existsSync(localNodeModules)) {
       cloneDir = join(localNodeModules, ".c12", cloneName);
     } else {
       cloneDir = process.env.XDG_CACHE_HOME


### PR DESCRIPTION


### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As extension to https://github.com/unjs/c12/pull/109. When cloning a layer, it will be extracted to `node_modules/.c12/{name}` if `{cwd}/node_module` exists but the sub-layer, won't be because `node_modules/.c12/node_modules` does not! With this PR, sublayer will be clonned into parent `node_module/.c12`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
