### PR TITLE
fix: json5 `parse` is not a function

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -331,8 +331,8 @@ async function resolveConfig<
     const { parse } = await import("jsonc-parser");
     res.config = parse(await readFile(res.configFile!, "utf8"));
   } else if (res.configFile!.endsWith(".json5")) {
-    const { parse } = await import("json5");
-    res.config = parse(await readFile(res.configFile!, "utf8"));
+    const json5 = await import("json5").then(m => m.default);
+    res.config = json5.parse(await readFile(res.configFile!, "utf8"));
   } else {
     res.config = options.jiti!(res.configFile!);
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

None

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

on the Windows and Stackblitz environment, I have `json5` error like `TypeError: parse is not a function`

https://www.npmjs.com/package/json5?activeTab=code

---

Please check this Stackblitz playground it has two c12 build files (.tgz)

- file:c12-1.7.1.tgz ❌ 
- file:c12-1.7.2.tgz ✅ 

https://stackblitz.com/edit/vitejs-vite-kwdgy9


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
