### PR TITLE
fix: deep merge rc sources with defu

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -84,9 +84,9 @@ export async function loadConfig<
   }
 
   // Load rc files
-  let configRC = Object.create(null) as T;
+  const configRC = {};
   if (options.rcFile) {
-    const rcSources = [];
+    const rcSources: T[] = [];
     // 1. cwd
     rcSources.push(rc9.read({ name: options.rcFile, dir: options.cwd }));
     if (options.globalRc) {
@@ -98,7 +98,7 @@ export async function loadConfig<
       // 3. user home
       rcSources.push(rc9.readUser({ name: options.rcFile, dir: options.cwd }));
     }
-    configRC = defu({}, ...rcSources) as T;
+    Object.assign(configRC, defu({}, ...rcSources));
   }
 
   // Load config from package.json

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -84,24 +84,24 @@ export async function loadConfig<
   }
 
   // Load rc files
-  const configRC = {};
+  let configRC = {};
   if (options.rcFile) {
     if (options.globalRc) {
-      Object.assign(
-        configRC,
+      configRC = defu(
         rc9.readUser({ name: options.rcFile, dir: options.cwd }),
+        configRC,
       );
       const workspaceDir = await findWorkspaceDir(options.cwd).catch(() => {});
       if (workspaceDir) {
-        Object.assign(
-          configRC,
+        configRC = defu(
           rc9.read({ name: options.rcFile, dir: workspaceDir }),
+          configRC,
         );
       }
     }
-    Object.assign(
-      configRC,
+    configRC = defu(
       rc9.read({ name: options.rcFile, dir: options.cwd }),
+      configRC,
     );
   }
 


### PR DESCRIPTION
If we take two RC files:

```
# ~/.nuxtrc
telemetry.consent=1
telemetry.seed=abc
telemetry.enabled=true
```

```
# ./.nuxrc
telemetry.consent=0
```

The current config returned is:


```ts
{
  telemetry: {
    consent: 0
  }
}
```

With this fix, it will return:

```ts
{
  telemetry: {
    seed: 'abc',
    enabled: true,
    consent: 0
  }
}
```