### PR TITLE
feat:  Provide fallback values

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -8,6 +8,7 @@ import { defu } from "defu";
 import { hash } from "ohash";
 import { findWorkspaceDir, readPackageJSON } from "pkg-types";
 import { setupDotenv } from "./dotenv";
+import { provideFallbackValues } from "./utils";
 
 import type {
   UserInputConfig,
@@ -131,6 +132,10 @@ export async function loadConfig<
     const pkgJsonFile = await readPackageJSON(options.cwd).catch(() => {});
     const values = keys.map((key) => pkgJsonFile?.[key]);
     Object.assign(pkgJson, defu({}, ...values));
+  }
+
+  if (options.provideFallbackValues && config) {
+    provideFallbackValues(config);
   }
 
   // Combine sources

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,8 @@ export interface LoadConfigOptions<
     | {
         extendKey?: string | string[];
       };
+
+  provideFallbackValues?: boolean;
 }
 
 export type DefineConfig<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,9 @@
+export function provideFallbackValues(obj: Record<string, any>) {
+  for (const key in obj) {
+    if (obj[key] === undefined || obj[key] === null) {
+      obj[key] = "";
+    } else if (typeof obj[key] === "object") {
+      provideFallbackValues(obj[key]);
+    }
+  }
+}

--- a/test/fixture/.config/test.ts
+++ b/test/fixture/.config/test.ts
@@ -16,4 +16,6 @@ export default {
   // foo: "bar",
   // x: "123",
   array: ["a"],
+  undefinedKey: undefined,
+  nullKey: null,
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -117,6 +117,7 @@ describe("c12", () => {
                 },
               ],
             ],
+            "nullKey": null,
             "overriden": false,
             "theme": "./theme",
           },
@@ -282,5 +283,75 @@ describe("c12", () => {
       (layer) => layer.configFile === "<path>/fixture/.base/test.config.jsonc",
     )!;
     expect(Object.keys(baseLayerConfig.config!)).toContain("$env");
+  });
+
+  it("provides fallback values", async () => {
+    type UserConfig = Partial<{
+      virtual: boolean;
+      overriden: boolean;
+      defaultConfig: boolean;
+      extends: string[];
+    }>;
+    const { config } = await loadConfig<UserConfig>({
+      cwd: r("./fixture"),
+      provideFallbackValues: true,
+      name: "test",
+      dotenv: true,
+      packageJson: ["c12", "c12-alt"],
+      globalRc: true,
+      envName: "test",
+      extend: {
+        extendKey: ["theme", "extends"],
+      },
+      overrides: {
+        overriden: true,
+      },
+      defaults: {
+        defaultConfig: true,
+      },
+      defaultConfig: {
+        extends: ["virtual"],
+      },
+    });
+
+    expect(transformPaths(config!)).toMatchInlineSnapshot(`
+      {
+        "$env": {
+          "test": {
+            "baseEnvConfig": true,
+          },
+        },
+        "$test": {
+          "envConfig": true,
+          "extends": [
+            "./test.config.dev",
+          ],
+        },
+        "array": [
+          "a",
+          "b",
+        ],
+        "baseConfig": true,
+        "baseEnvConfig": true,
+        "colors": {
+          "primary": "user_primary",
+          "secondary": "theme_secondary",
+          "text": "base_text",
+        },
+        "configFile": true,
+        "defaultConfig": true,
+        "devConfig": true,
+        "envConfig": true,
+        "githubLayer": true,
+        "npmConfig": true,
+        "nullKey": "",
+        "overriden": true,
+        "packageJSON": true,
+        "packageJSON2": true,
+        "rcFile": true,
+        "testConfig": true,
+        "undefinedKey": "",
+      }
+    `);
   });
 });


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/issues/2270

### ❓ Type of change

Provides a new option called `provideFallbackValues` that replaces `null` or `undefined` with an empty string to not be stripped off by defu.
