### PR TITLE
feat: resolvable configs

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,20 @@ export interface ResolvedConfig<
   cwd?: string;
 }
 
+export interface ResolvableConfigContext<
+  T extends UserInputConfig = UserInputConfig,
+> {
+  configs: Record<
+    "overrides" | "main" | "rc" | "packageJson" | "defaultConfig",
+    T | null | undefined
+  >;
+}
+
+type MaybePromise<T> = T | Promise<T>;
+export type ResolvableConfig<T extends UserInputConfig = UserInputConfig> =
+  | MaybePromise<T | null | undefined>
+  | ((ctx: ResolvableConfigContext<T>) => MaybePromise<T | null | undefined>);
+
 export interface LoadConfigOptions<
   T extends UserInputConfig = UserInputConfig,
   MT extends ConfigLayerMeta = ConfigLayerMeta,
@@ -98,9 +112,9 @@ export interface LoadConfigOptions<
 
   packageJson?: boolean | string | string[];
 
-  defaults?: T;
-  defaultConfig?: T;
-  overrides?: T;
+  defaults?: ResolvableConfig<T>;
+  defaultConfig?: ResolvableConfig<T>;
+  overrides?: ResolvableConfig<T>;
 
   omit$Keys?: boolean;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,7 +112,8 @@ export interface LoadConfigOptions<
 
   packageJson?: boolean | string | string[];
 
-  defaults?: ResolvableConfig<T>;
+  defaults?: T;
+
   defaultConfig?: ResolvableConfig<T>;
   overrides?: ResolvableConfig<T>;
 

--- a/test/fixture/.config/test.ts
+++ b/test/fixture/.config/test.ts
@@ -13,6 +13,7 @@ export default {
   },
   configFile: true,
   overriden: false,
+  enableDefault: true,
   // foo: "bar",
   // x: "123",
   array: ["a"],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,6 +14,7 @@ describe("c12", () => {
     type UserConfig = Partial<{
       virtual: boolean;
       overriden: boolean;
+      enableDefault: boolean;
       defaultConfig: boolean;
       extends: string[];
     }>;
@@ -38,8 +39,13 @@ describe("c12", () => {
       defaults: {
         defaultConfig: true,
       },
-      defaultConfig: {
-        extends: ["virtual"],
+      defaultConfig: ({ configs }) => {
+        if (configs?.main?.enableDefault) {
+          return Promise.resolve({
+            extends: ["virtual"],
+          });
+        }
+        return {};
       },
     });
 
@@ -70,6 +76,7 @@ describe("c12", () => {
         "configFile": true,
         "defaultConfig": true,
         "devConfig": true,
+        "enableDefault": true,
         "envConfig": true,
         "githubLayer": true,
         "npmConfig": true,
@@ -104,6 +111,7 @@ describe("c12", () => {
               "primary": "user_primary",
             },
             "configFile": true,
+            "enableDefault": true,
             "envConfig": true,
             "extends": [
               "./test.config.dev",


### PR DESCRIPTION
This PR adds support for config sources (defaults, overrides, and user main config) to be also a (sync/async) function or promise.

Main initiative of this is to allow Nitro's default object infer user options (compatibilityDate) **before merge** but this feature generally should open new conventional usecases of async configs..
