### PR TITLE
fix(loadConfig): return type's `config` is not nullable

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface ResolvedConfig<
   T extends UserInputConfig = UserInputConfig,
   MT extends ConfigLayerMeta = ConfigLayerMeta,
 > extends ConfigLayer<T, MT> {
+  config: T;
   layers?: ConfigLayer<T, MT>[];
   cwd?: string;
 }


### PR DESCRIPTION
**Reference:** resolves #41