### PR TITLE
feat: allow disabling remote extend with `giget: false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,6 @@ The final config is merged result of extended options and user options with [unj
 Each item in extends is a string that can be either an absolute or relative path to the current config file pointing to a config file for extending or the directory containing the config file.
 If it starts with either `github:`, `gitlab:`, `bitbucket:`, or `https:`, c12 automatically clones it.
 
-You can set the `extendOptions` option when loading the config (with `loadConfig`) to customize the extending behavior like ignoring remote sources.
-
 For custom merging strategies, you can directly access each layer with `layers` property.
 
 **Example:**
@@ -306,7 +304,7 @@ export default {
 };
 ```
 
-You can pass more options to `giget: {}` in layer config.
+You can pass more options to `giget: {}` in layer config or disable it by setting it to `false`.
 
 Refer to [unjs/giget](https://giget.unjs.io) for more information.
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ The final config is merged result of extended options and user options with [unj
 Each item in extends is a string that can be either an absolute or relative path to the current config file pointing to a config file for extending or the directory containing the config file.
 If it starts with either `github:`, `gitlab:`, `bitbucket:`, or `https:`, c12 automatically clones it.
 
+You can set the `extendOptions` option when loading the config (with `loadConfig`) to customize the extending behavior like ignoring remote sources.
+
 For custom merging strategies, you can directly access each layer with `layers` property.
 
 **Example:**

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -250,6 +250,25 @@ async function extendConfig<
       );
       continue;
     }
+
+    // Skipping remote sources if set up
+    const skipRemote = options?.extendOptions?.skipRemote;
+    const isGiGetSource = GIGET_PREFIXES.some((prefix) =>
+      extendSource.startsWith(prefix),
+    );
+    const isNPMSource = NPM_PACKAGE_RE.test(extendSource);
+    if (skipRemote && (isNPMSource || isGiGetSource)) {
+      if (skipRemote === true) continue;
+
+      const hasAuth = Boolean((sourceOptions as SourceOptions)?.auth);
+      const skippingGitgetSource =
+        isGiGetSource && !(hasAuth ? skipRemote.allowAuth : false);
+      if (skippingGitgetSource) continue;
+
+      const skippingNPMSource = isNPMSource && !skipRemote.allowNPM;
+      if (skippingNPMSource) continue;
+    }
+
     const _config = await resolveConfig(extendSource, options, sourceOptions);
     if (!_config.config) {
       // TODO: Use error in next major versions

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -250,7 +250,6 @@ async function extendConfig<
       );
       continue;
     }
-
     const _config = await resolveConfig(extendSource, options, sourceOptions);
     if (!_config.config) {
       // TODO: Use error in next major versions

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -251,24 +251,6 @@ async function extendConfig<
       continue;
     }
 
-    // Skipping remote sources if set up
-    const skipRemote = options?.extendOptions?.skipRemote;
-    const isGiGetSource = GIGET_PREFIXES.some((prefix) =>
-      extendSource.startsWith(prefix),
-    );
-    const isNPMSource = NPM_PACKAGE_RE.test(extendSource);
-    if (skipRemote && (isNPMSource || isGiGetSource)) {
-      if (skipRemote === true) continue;
-
-      const hasAuth = Boolean((sourceOptions as SourceOptions)?.auth);
-      const skippingGitgetSource =
-        isGiGetSource && !(hasAuth ? skipRemote.allowAuth : false);
-      if (skippingGitgetSource) continue;
-
-      const skippingNPMSource = isNPMSource && !skipRemote.allowNPM;
-      if (skippingNPMSource) continue;
-    }
-
     const _config = await resolveConfig(extendSource, options, sourceOptions);
     if (!_config.config) {
       // TODO: Use error in next major versions
@@ -321,7 +303,10 @@ async function resolveConfig<
   const _merger = options.merger || defu;
 
   // Download giget URIs and resolve to local path
-  if (GIGET_PREFIXES.some((prefix) => source.startsWith(prefix))) {
+  const isGigetSource = GIGET_PREFIXES.some((prefix) =>
+    source.startsWith(prefix),
+  );
+  if (options.giget !== false && isGigetSource) {
     const { downloadTemplate } = await import("giget");
 
     const cloneName =

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -303,10 +303,10 @@ async function resolveConfig<
   const _merger = options.merger || defu;
 
   // Download giget URIs and resolve to local path
-  const isGigetSource = GIGET_PREFIXES.some((prefix) =>
-    source.startsWith(prefix),
-  );
-  if (options.giget !== false && isGigetSource) {
+  if (
+    options.giget !== false &&
+    GIGET_PREFIXES.some((prefix) => source.startsWith(prefix))
+  ) {
     const { downloadTemplate } = await import("giget");
 
     const cloneName =

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,27 @@ export interface LoadConfigOptions<
     | {
         extendKey?: string | string[];
       };
+  /**
+   * Options for extending configs
+   */
+  extendOptions?: {
+    /**
+     * Skip and ignore remote configs when extending. This blocks downloading configs
+     * from github or npm, only local configs will be used.
+     */
+    skipRemote?:
+      | boolean
+      | {
+          /**
+           * Allow extending configs with auth tokens.
+           */
+          allowAuth?: boolean;
+          /**
+           * Allow extending configs from npm.
+           */
+          allowNPM?: boolean;
+        };
+  };
 }
 
 export type DefineConfig<

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,7 +131,7 @@ export interface LoadConfigOptions<
   jiti?: Jiti;
   jitiOptions?: JitiOptions;
 
-  giget?: DownloadTemplateOptions;
+  giget?: false | DownloadTemplateOptions;
 
   merger?: (...sources: Array<T | null | undefined>) => T;
 
@@ -140,27 +140,6 @@ export interface LoadConfigOptions<
     | {
         extendKey?: string | string[];
       };
-  /**
-   * Options for extending configs
-   */
-  extendOptions?: {
-    /**
-     * Skip and ignore remote configs when extending. This blocks downloading configs
-     * from github or npm, only local configs will be used.
-     */
-    skipRemote?:
-      | boolean
-      | {
-          /**
-           * Allow extending configs with auth tokens.
-           */
-          allowAuth?: boolean;
-          /**
-           * Allow extending configs from npm.
-           */
-          allowNPM?: boolean;
-        };
-  };
 }
 
 export type DefineConfig<

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -233,6 +233,14 @@ describe("loader", () => {
         extends: ["github:unjs/c12/test/fixture"],
       },
     });
+    const { config: nonExtendingConfig } = await loadConfig({
+      name: "test",
+      cwd: r("./fixture/new_dir"),
+      giget: false,
+      overrides: {
+        extends: ["github:unjs/c12/test/fixture"],
+      },
+    });
 
     expect(transformPaths(config!)).toMatchInlineSnapshot(`
       {
@@ -258,56 +266,9 @@ describe("loader", () => {
         "theme": "./theme",
       }
     `);
-  });
 
-  it("skip remote configs", async () => {
-    type Config = {
-      extends?: string[];
-      defaultValue?: boolean;
-      npmValue?: boolean;
-    };
-    const opts = {
-      name: "test",
-      cwd: r("./fixture/new_dir"),
-      overrides: {
-        extends: ["virtual", "github:unjs/c12/test/fixture"],
-      },
-      resolve: (id: string) => {
-        if (id === "virtual") {
-          return { config: { npmValue: true } };
-        }
-      },
-      defaultConfig: {
-        defaultValue: true,
-      },
-    };
-    const { config: remoteConfig } = await loadConfig<Config>({
-      ...opts,
-      extendOptions: {
-        skipRemote: true,
-      },
-    });
-
-    const { config: npmConfig } = await loadConfig<Config>({
-      ...opts,
-      extendOptions: {
-        skipRemote: {
-          allowAuth: false,
-          allowNPM: true,
-        },
-      },
-    });
-
-    expect(transformPaths(remoteConfig!)).toMatchInlineSnapshot(`
-      {
-        "defaultValue": true,
-      }
-    `);
-    expect(transformPaths(npmConfig!)).toMatchInlineSnapshot(`
-      {
-        "defaultValue": true,
-        "npmValue": true,
-      }
+    expect(transformPaths(nonExtendingConfig!)).toMatchInlineSnapshot(`
+      {}
     `);
   });
 

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -260,6 +260,57 @@ describe("loader", () => {
     `);
   });
 
+  it("skip remote configs", async () => {
+    type Config = {
+      extends?: string[];
+      defaultValue?: boolean;
+      npmValue?: boolean;
+    };
+    const opts = {
+      name: "test",
+      cwd: r("./fixture/new_dir"),
+      overrides: {
+        extends: ["virtual", "github:unjs/c12/test/fixture"],
+      },
+      resolve: (id: string) => {
+        if (id === "virtual") {
+          return { config: { npmValue: true } };
+        }
+      },
+      defaultConfig: {
+        defaultValue: true,
+      },
+    };
+    const { config: remoteConfig } = await loadConfig<Config>({
+      ...opts,
+      extendOptions: {
+        skipRemote: true,
+      },
+    });
+
+    const { config: npmConfig } = await loadConfig<Config>({
+      ...opts,
+      extendOptions: {
+        skipRemote: {
+          allowAuth: false,
+          allowNPM: true,
+        },
+      },
+    });
+
+    expect(transformPaths(remoteConfig!)).toMatchInlineSnapshot(`
+      {
+        "defaultValue": true,
+      }
+    `);
+    expect(transformPaths(npmConfig!)).toMatchInlineSnapshot(`
+      {
+        "defaultValue": true,
+        "npmValue": true,
+      }
+    `);
+  });
+
   it("omit$Keys", async () => {
     const { config, layers } = await loadConfig({
       name: "test",


### PR DESCRIPTION
resolves #180

When loading in user configs we don't always want to import remote non-trusted code in code-based config files (`.js`, `.ts`, ...). This PR adds the option to disable remote extending while still supporting extensions of local config files.
