### PR TITLE
Implement override functionality in setupDotEnv and loadDotEnv functions

### DIFF
--- a/src/dotenv.ts
+++ b/src/dotenv.ts
@@ -31,6 +31,12 @@ export interface DotenvOptions {
    */
 
   env?: NodeJS.ProcessEnv;
+
+  /**
+   * When set to `true`, any existing environment variables will be overridden.
+   * Defaults to `false`.
+   */
+  override?: boolean;
 }
 
 export type Env = typeof process.env;
@@ -49,12 +55,17 @@ export async function setupDotenv(options: DotenvOptions): Promise<Env> {
     fileName: options.fileName ?? ".env",
     env: targetEnvironment,
     interpolate: options.interpolate ?? true,
+    override: options.override ?? false,
   });
 
   // Fill process.env
   for (const key in environment) {
-    if (!key.startsWith("_") && targetEnvironment[key] === undefined) {
-      targetEnvironment[key] = environment[key];
+    if (!key.startsWith("_")) {
+      if (options.override) {
+        targetEnvironment[key] = environment[key];
+      } else if (targetEnvironment[key] === undefined) {
+        targetEnvironment[key] = environment[key];
+      }
     }
   }
 
@@ -74,7 +85,15 @@ export async function loadDotenv(options: DotenvOptions): Promise<Env> {
 
   // Apply process.env
   if (!options.env?._applied) {
-    Object.assign(environment, options.env);
+    if (options.override && options.env) {
+      for (const key in options.env) {
+        if (!(key in environment) && !key.startsWith("_")) {
+          environment[key] = options.env[key];
+        }
+      }
+    } else {
+      Object.assign(environment, options.env);
+    }
     environment._applied = true;
   }
 


### PR DESCRIPTION
This is an issue related to a draft PR I raised in https://github.com/nuxt/cli/pull/466

### Issue Description
- `setupDotEnv` function is called with a `.env` file. Assume that the only env var loaded is `FLAG`.
- The `FLAG` variable's value is updated in the `.env` file by the running process.
- `setupDotEnv` is called again, but the value of `process.env.FLAG` is not changed.

Reproduce the issue: https://stackblitz.com/edit/stackblitz-starters-xnps4y?file=.env,index.js

I have introduced an `override` flag in `DotenvOptions`, which gives precedence to the env variable values in the `.env` file over the existing values in `process.env`.

With this change, the PR https://github.com/nuxt/cli/pull/466 can be simplified and we can use this new flag directly.