### PR TITLE
fix: preserve `meta` for main config

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -115,6 +115,10 @@ export async function loadConfig<
     r.configFile = _mainConfig.configFile;
   }
 
+  if (_mainConfig.meta) {
+    r.meta = _mainConfig.meta;
+  }
+
   // Load rc files
   if (options.rcFile) {
     const rcSources: T[] = [];


### PR DESCRIPTION
Previously it was impossible to get metadata for the main layer, meaning if you wanted to develop a layer with reference to its own metadata this was not available from the resolved config.