### PR TITLE
refactor: upgrade to ohash v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "giget": "^1.2.4",
     "jiti": "^2.4.2",
     "mlly": "^1.7.4",
-    "ohash": "^1.1.4",
+    "ohash": "^2.0.4",
     "pathe": "^2.0.3",
     "perfect-debounce": "^1.0.0",
     "pkg-types": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^1.7.4
         version: 1.7.4
       ohash:
-        specifier: ^1.1.4
-        version: 1.1.4
+        specifier: ^2.0.4
+        version: 2.0.4
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -1642,6 +1642,9 @@ packages:
 
   ohash@1.1.4:
     resolution: {integrity: sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==}
+
+  ohash@2.0.4:
+    resolution: {integrity: sha512-ac+SFwzhdHb0hp48/dbR7Jta39qfbuj7t3hApd9uyHS8bisHTfVzSEvjOVgV0L3zG7VR2/7JjkSGimP75D+hOQ==}
 
   open@10.1.0:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
@@ -3887,6 +3890,8 @@ snapshots:
       ufo: 1.5.4
 
   ohash@1.1.4: {}
+
+  ohash@2.0.4: {}
 
   open@10.1.0:
     dependencies:

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -6,7 +6,6 @@ import { createJiti } from "jiti";
 import { fileURLToPath } from "mlly";
 import * as rc9 from "rc9";
 import { defu } from "defu";
-import { hash } from "ohash";
 import { findWorkspaceDir, readPackageJSON } from "pkg-types";
 import { setupDotenv } from "./dotenv";
 
@@ -312,11 +311,12 @@ async function resolveConfig<
     GIGET_PREFIXES.some((prefix) => source.startsWith(prefix))
   ) {
     const { downloadTemplate } = await import("giget");
+    const { digest } = await import("ohash");
 
     const cloneName =
       source.replace(/\W+/g, "_").split("_").splice(0, 3).join("_") +
       "_" +
-      hash(source);
+      digest(source).slice(0, 10).replace(/[-_]/g, "");
 
     let cloneDir: string;
 

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,7 +1,7 @@
 import type { ChokidarOptions } from "chokidar";
 import { debounce } from "perfect-debounce";
 import { resolve } from "pathe";
-import { diff } from "ohash";
+import type { diff } from "ohash/utils";
 import type {
   UserInputConfig,
   ConfigLayerMeta,
@@ -9,6 +9,8 @@ import type {
   LoadConfigOptions,
 } from "./types";
 import { SUPPORTED_EXTENSIONS, loadConfig } from "./loader";
+
+type DiffEntries = ReturnType<typeof diff>;
 
 export type ConfigWatcher<
   T extends UserInputConfig = UserInputConfig,
@@ -31,7 +33,7 @@ export interface WatchConfigOptions<
   }) => void | Promise<void>;
 
   acceptHMR?: (context: {
-    getDiff: () => ReturnType<typeof diff>;
+    getDiff: () => DiffEntries;
     newConfig: ResolvedConfig<T, MT>;
     oldConfig: ResolvedConfig<T, MT>;
   }) => void | boolean | Promise<void | boolean>;
@@ -89,6 +91,7 @@ export async function watchConfig<
   ] as string[];
 
   const watch = await import("chokidar").then((r) => r.watch || r.default || r);
+  const { diff } = await import("ohash/utils");
   const _fswatcher = watch(watchingFiles, {
     ignoreInitial: true,
     ...options.chokidarOptions,


### PR DESCRIPTION
Upgrade to ohash v2.

Since it is ESM-only and c12 is not (yet!), we have to use dynamic imports.

`hash(path)` replaced with `digest(path).replace(-_, "").substring(0, 10)` to avoid breaking existing cache paths.