### PR TITLE
fix: check if `.env/` is a file before accessing

### DIFF
--- a/src/dotenv.ts
+++ b/src/dotenv.ts
@@ -1,4 +1,4 @@
-import { promises as fsp, existsSync } from "node:fs";
+import { promises as fsp, statSync } from "node:fs";
 import { resolve } from "pathe";
 import * as dotenv from "dotenv";
 
@@ -67,7 +67,7 @@ export async function loadDotenv(options: DotenvOptions): Promise<Env> {
 
   const dotenvFile = resolve(options.cwd, options.fileName!);
 
-  if (existsSync(dotenvFile)) {
+  if (statSync(dotenvFile, { throwIfNoEntry: false })?.isFile()) {
     const parsed = dotenv.parse(await fsp.readFile(dotenvFile, "utf8"));
     Object.assign(environment, parsed);
   }


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/31133

this checks whether `.env/` is a file before trying to read from it