### PR TITLE
fix: set flag on `options.env` to avoid double assignment

### DIFF
--- a/src/dotenv.ts
+++ b/src/dotenv.ts
@@ -75,7 +75,8 @@ export async function loadDotenv(options: DotenvOptions): Promise<Env> {
   // Apply process.env
   if (!options.env?._applied) {
     Object.assign(environment, options.env);
-    environment._applied = true;
+    // @ts-expect-error environment variables are strings
+    options.env._applied = true;
   }
 
   // Interpolate env


### PR DESCRIPTION
spotted while investigating https://github.com/nuxt/nuxt/issues/30444, it seems the following will happen at the moment:

1. .env file is loaded
2. process.env is applied to it
3. environment is augmented with value from .env
4. after a restart, env file will be loaded with an updated value
5. because process.env._applied is not set, the previous value from .env overrides the new value from .env

I'm not fully sure of the logic for setting `environment._applied` but it's a new object created in this function so I think will _never_ be true unless `_applied=true` is in the `.env` file.