### PR TITLE
fix: handle watcher reload errors

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -109,10 +109,14 @@ export async function watchConfig<
       });
     }
     const oldConfig = config;
-    const newConfig = await loadConfig(options);
-    config = newConfig;
+    try {
+      config = await loadConfig(options);
+    } catch (error) {
+      console.warn(`Failed to load config ${path}\n${error}`);
+      return;
+    }
     const changeCtx = {
-      newConfig,
+      newConfig: config,
       oldConfig,
       getDiff: () => diff(oldConfig.config, config.config),
     };


### PR DESCRIPTION
resolves https://github.com/nitrojs/nitro/issues/3365

In watcher/HMR mode, we need to handle loading errors (and feedback/wait user to fix) to avoid having global unhandled rejections.