### PR TITLE
chore: improve logging for parsing error

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -112,7 +112,7 @@ export async function watchConfig<
     try {
       config = await loadConfig(options);
     } catch (error) {
-      console.warn(`Failed to load config ${path}\n${error}`);
+      console.warn(`Failed to load config file at ${path}. Please check your config file for syntax errors.`);
       return;
     }
     const changeCtx = {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -112,7 +112,9 @@ export async function watchConfig<
     try {
       config = await loadConfig(options);
     } catch (error) {
-      console.warn(`Failed to load config file at ${path}. Please check your config file for syntax errors.`);
+      console.warn(
+        `Failed to load config file at ${path}. Please check your config file for errors. (${error})`,
+      );
       return;
     }
     const changeCtx = {


### PR DESCRIPTION
After discussing on Discord and examining the specific solution for #247 

Assume I have the following config: 

export default defineNitroConfig({
  srcDir: "server",
  compatibilityDate: "2025-05-17",
  preset: "vercel"
});

The proposed console.warn is hit on the following occasions: 

- Typing "defaut", or writing defineNitroConfig wrong
- Missing an " on a string value
- Missing a starting or ending ")" or "}"

They are all syntax errors and the users IDE hints on whats wrong. Javascript comes up with incorrect solutions to the observed issue.

For example when I remove "}" it says expecting "," which is wrong.

I think this message is better, I would prefer a warning triangle in front but I didn't find if we can use that.
   