### PR TITLE
feat: pass raw configs to function sources

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -155,6 +155,7 @@ export async function loadConfig<
 
   // Resolve config sources
   const configs = {} as Record<ConfigSource, T | null | undefined>;
+  // TODO: #253 change order from defaults to overrides in next major version
   for (const key in rawConfigs) {
     const value = rawConfigs[key as ConfigSource];
     configs[key as ConfigSource] = await (typeof value === "function"

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -19,7 +19,7 @@ import type {
   ConfigLayer,
   SourceOptions,
   InputConfig,
-  ResolvableConfigContext,
+  ConfigSource,
 } from "./types";
 
 const _normalize = (p?: string) => p?.replace(/\\/g, "/");
@@ -90,15 +90,16 @@ export async function loadConfig<
   };
 
   // prettier-ignore
-  type _ConfigName = keyof ResolvableConfigContext["configs"]
-  const _configs: Record<_ConfigName, ResolvableConfig<T> | null | undefined> =
-    {
-      overrides: options.overrides,
-      main: undefined,
-      rc: undefined,
-      packageJson: undefined,
-      defaultConfig: options.defaultConfig,
-    };
+  const rawConfigs: Record<
+    ConfigSource,
+    ResolvableConfig<T> | null | undefined
+  > = {
+    overrides: options.overrides,
+    main: undefined,
+    rc: undefined,
+    packageJson: undefined,
+    defaultConfig: options.defaultConfig,
+  };
 
   // Load dotenv
   if (options.dotenv) {
@@ -111,7 +112,7 @@ export async function loadConfig<
   // Load main config file
   const _mainConfig = await resolveConfig(".", options);
   if (_mainConfig.configFile) {
-    _configs.main = _mainConfig.config;
+    rawConfigs.main = _mainConfig.config;
     r.configFile = _mainConfig.configFile;
   }
 
@@ -133,7 +134,7 @@ export async function loadConfig<
       // 3. user home
       rcSources.push(rc9.readUser({ name: options.rcFile, dir: options.cwd }));
     }
-    _configs.rc = _merger({} as T, ...rcSources);
+    rawConfigs.rc = _merger({} as T, ...rcSources);
   }
 
   // Load config from package.json
@@ -149,15 +150,15 @@ export async function loadConfig<
     ).filter((t) => t && typeof t === "string");
     const pkgJsonFile = await readPackageJSON(options.cwd).catch(() => {});
     const values = keys.map((key) => pkgJsonFile?.[key]);
-    _configs.packageJson = _merger({} as T, ...values);
+    rawConfigs.packageJson = _merger({} as T, ...values);
   }
 
   // Resolve config sources
-  const configs = {} as Record<_ConfigName, T | null | undefined>;
-  for (const key in _configs) {
-    const value = _configs[key as _ConfigName];
-    configs[key as _ConfigName] = await (typeof value === "function"
-      ? value({ configs })
+  const configs = {} as Record<ConfigSource, T | null | undefined>;
+  for (const key in rawConfigs) {
+    const value = rawConfigs[key as ConfigSource];
+    configs[key as ConfigSource] = await (typeof value === "function"
+      ? value({ configs, rawConfigs })
       : value);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,13 +80,18 @@ export interface ResolvedConfig<
   cwd?: string;
 }
 
+export type ConfigSource =
+  | "overrides"
+  | "main"
+  | "rc"
+  | "packageJson"
+  | "defaultConfig";
+
 export interface ResolvableConfigContext<
   T extends UserInputConfig = UserInputConfig,
 > {
-  configs: Record<
-    "overrides" | "main" | "rc" | "packageJson" | "defaultConfig",
-    T | null | undefined
-  >;
+  configs: Record<ConfigSource, T | null | undefined>;
+  rawConfigs: Record<ConfigSource, ResolvableConfig<T> | null | undefined>;
 }
 
 type MaybePromise<T> = T | Promise<T>;


### PR DESCRIPTION
Context: Required by https://github.com/nitrojs/nitro/pull/3467

When sources like `overrides` or `defaults` are a custom function to extend from other sources, they might need access to not immediately resolved configs from other sources (as order matters, it wasn't needed for nitro case of `default` before `configs` had all resolved values while `overrides` needs it, we probably need to make a breaking behavior change to fix root cause later)