### PR TITLE
chore(readme): add prisma to the "used by" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ c12 (pronounced as /siːtwelv/, like c-twelve) is a smart configuration loader.
 - [RemixKit](https://github.com/jrestall/remix-kit)
 - [Hey API](https://github.com/hey-api/openapi-ts)
 - [kysely-ctl](https://github.com/kysely-org/kysely-ctl)
+- [Prisma](https://github.com/prisma/prisma)
 
 ## Usage
 


### PR DESCRIPTION
Hey there, Alberto from [Prisma](https://github.com/prisma/prisma) here.
Thank you for this project!

I've updated the README.md file to indicate that `c12` will be used by Prisma too starting from v6.13.0, which will be released on July 29th. Feel free to check out the corresponding PR (https://github.com/prisma/prisma/pull/27672), which is already merged in our `main` branch.

Cheers 👋🏻