### PR TITLE
feat: support scoped env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ Load RC config from the workspace directory and the user's home directory. Only 
 
 Loads `.env` file if enabled. It is disabled by default.
 
+```
+.env:              always loaded.
+.env.local:        always loaded.
+.env.[mode]:       loaded only when mode is defined.
+.env.[mode].local: loaded only when mode is defined.
+```
+
+#### Env Loading Priorities
+
+c12 consistently loads `.env` and `.env.local` files, along with the mode-specific file `.env.[mode]` and `.env.[mode].local`. Variables in the mode-specific file override those in the generic files. However, any variables defined exclusively in `.env` or `.env.local` remain accessible within the environment.
+Environment files with specific mode take precedence, letting you customize settings for particular environments.
+
 ### `packageJson`
 
 Loads config from nearest `package.json` file. It is disabled by default.

--- a/test/dotenv.test.ts
+++ b/test/dotenv.test.ts
@@ -40,4 +40,35 @@ describe("update config file", () => {
     await setupDotenv({ cwd: tmpDir });
     expect(process.env.override).toBe("os");
   });
+
+  it("should load envs files with the correct priorities", async () => {
+    await writeFile(r(".env"), "BASE=base");
+    await setupDotenv({ cwd: tmpDir });
+    expect(process.env.BASE).toBe("base");
+
+    delete process.env.BASE;
+    await writeFile(r(".env"), "BASE=base");
+    await writeFile(r(".env.local"), "BASE=local");
+    await setupDotenv({ cwd: tmpDir, mode: "dev" });
+    expect(process.env.BASE).toBe("local");
+
+    delete process.env.BASE;
+    await writeFile(r(".env"), "BASE=base");
+    await writeFile(r(".env.local"), "BASE=local");
+    await writeFile(r(".env.local"), "FOO=bar");
+    await writeFile(r(".env.dev"), "BASE=dev");
+    await setupDotenv({ cwd: tmpDir, mode: "dev" });
+    expect(process.env.BASE).toBe("dev");
+    expect(process.env.FOO).toBe("bar");
+
+    delete process.env.BASE;
+    await writeFile(r(".env"), "BASE=base");
+    await writeFile(r(".env"), "FOO=bar");
+    await writeFile(r(".env.local"), "BASE=local");
+    await writeFile(r(".env.dev"), "BASE=dev");
+    await writeFile(r(".env.dev.local"), "BASE=dev_local");
+    await setupDotenv({ cwd: tmpDir, mode: "dev" });
+    expect(process.env.BASE).toBe("dev_local");
+    expect(process.env.FOO).toBe("bar");
+  });
 });


### PR DESCRIPTION
Resolves #68

This PR add the possibility to define scoped env files based on the optional property mode.
I followed the [same logic Vite is using](https://vite.dev/guide/env-and-mode.html#env-files) to prioritise the env variables. 

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
