### PR TITLE
feat: support loading load secrets from file

### DIFF
--- a/src/dotenv.ts
+++ b/src/dotenv.ts
@@ -113,10 +113,7 @@ export async function loadDotenv(options: DotenvOptions): Promise<Env> {
         const targetKey = key.slice(0, -5);
         if (environment[targetKey] === undefined) {
           const filePath = environment[key];
-          if (
-            filePath &&
-            statSync(filePath, { throwIfNoEntry: false })?.isFile()
-          ) {
+          if (filePath && statSync(filePath, { throwIfNoEntry: false })?.isFile()) {
             const value = await fsp.readFile(filePath, "utf8");
             environment[targetKey] = value.trim();
             dotenvVars.add(targetKey);

--- a/test/dotenv.test.ts
+++ b/test/dotenv.test.ts
@@ -77,17 +77,13 @@ describe("update config file", () => {
     process.env.TEST_SECRET_FILE = "normal-secret-into-key-with-file-suffix";
 
     await setupDotenv({ cwd: tmpDir, expandEnvFiles: false });
-    expect(process.env.TEST_SECRET_FILE).toBe(
-      "normal-secret-into-key-with-file-suffix",
-    );
+    expect(process.env.TEST_SECRET_FILE).toBe("normal-secret-into-key-with-file-suffix");
   });
 
   it("should not support _FILE env vars by default (backward compatibility)", async () => {
     process.env.TEST_SECRET_FILE = "normal-secret-into-key-with-file-suffix";
 
     await setupDotenv({ cwd: tmpDir });
-    expect(process.env.TEST_SECRET_FILE).toBe(
-      "normal-secret-into-key-with-file-suffix",
-    );
+    expect(process.env.TEST_SECRET_FILE).toBe("normal-secret-into-key-with-file-suffix");
   });
 });


### PR DESCRIPTION
Resolve issue #289 

I added a feature flag `expandEnvFiles` with a default value of `false` to ensure the package remains compatible with the previous version, in case the user already has an envvar with a suffix `_FILE`.

I assume the flag can be removed in a future major version.