### PR TITLE
fix(loader): use statSync to detect directories with dots in name

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -353,8 +353,7 @@ async function resolveConfig<
   // Import from local fs
   const ext = extname(source);
   const resolvedPath = resolve(options.cwd!, source);
-  const isDir = _isDirectory(resolvedPath)
-    ?? (!ext || ext === basename(source)); /* #71 */
+  const isDir = _isDirectory(resolvedPath) ?? (!ext || ext === basename(source)); /* #71 */
   const cwd = resolve(options.cwd!, isDir ? source : dirname(source));
   if (isDir) {
     source = options.configFile!;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -353,9 +353,8 @@ async function resolveConfig<
   // Import from local fs
   const ext = extname(source);
   const resolvedPath = resolve(options.cwd!, source);
-  const isDir = existsSync(resolvedPath)
-    ? statSync(resolvedPath).isDirectory()
-    : !ext || ext === basename(source); /* #71 */
+  const isDir = _isDirectory(resolvedPath)
+    ?? (!ext || ext === basename(source)); /* #71 */
   const cwd = resolve(options.cwd!, isDir ? source : dirname(source));
   if (isDir) {
     source = options.configFile!;
@@ -453,4 +452,13 @@ function tryResolve(id: string, options: LoadConfigOptions<any, any>) {
     cache: false,
   });
   return res ? normalize(res) : undefined;
+}
+
+/** Returns `true`/`false` if the path exists, `null` if it doesn't. */
+function _isDirectory(path: string): boolean | null {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return null;
+  }
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import { homedir } from "node:os";
@@ -350,7 +350,10 @@ async function resolveConfig<
 
   // Import from local fs
   const ext = extname(source);
-  const isDir = !ext || ext === basename(source); /* #71 */
+  const resolvedPath = resolve(options.cwd!, source);
+  const isDir = existsSync(resolvedPath)
+    ? statSync(resolvedPath).isDirectory()
+    : !ext || ext === basename(source); /* #71 */
   const cwd = resolve(options.cwd!, isDir ? source : dirname(source));
   if (isDir) {
     source = options.configFile!;

--- a/test/fixture/multi-dot-extends/test.config.json5
+++ b/test/fixture/multi-dot-extends/test.config.json5
@@ -1,0 +1,4 @@
+{
+  extends: ["../my.dotted.layer"],
+  baseKey: true,
+}

--- a/test/fixture/my.dotted.layer/.config/test.config.json5
+++ b/test/fixture/my.dotted.layer/.config/test.config.json5
@@ -1,0 +1,3 @@
+{
+  multiDotLayer: true,
+}

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -377,4 +377,20 @@ describe("loader", () => {
       cwd: r("./fixture/jsx"),
     });
   });
+
+  it("extends from a directory whose name contains multiple dots (#278)", async () => {
+    const { config, layers } = await loadConfig({
+      name: "test",
+      cwd: r("./fixture/multi-dot-extends"),
+      extend: {
+        extendKey: "extends",
+      },
+    });
+    // The multi-dot dir should be resolved as a directory, not a file
+    const multiDotLayer = layers?.find((l) => l.cwd && l.cwd.includes("my.dotted.layer"));
+    expect(multiDotLayer).toBeDefined();
+    expect(multiDotLayer?.config).toMatchObject({ multiDotLayer: true });
+    // Base config key should still be present (merged)
+    expect(config).toMatchObject({ baseKey: true });
+  });
 });

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -390,7 +390,7 @@ describe("loader", () => {
     const multiDotLayer = layers?.find((l) => l.cwd && l.cwd.includes("my.dotted.layer"));
     expect(multiDotLayer).toBeDefined();
     expect(multiDotLayer?.config).toMatchObject({ multiDotLayer: true });
-    // Base config key should still be present (merged)
-    expect(config).toMatchObject({ baseKey: true });
+    // Base config key and extended layer key should both be present (merged)
+    expect(config).toMatchObject({ baseKey: true, multiDotLayer: true });
   });
 });


### PR DESCRIPTION
## Problem

Fixes #278.

Directories whose names contain multiple dots (e.g. `my.layer`, `foo.bar.baz`) cannot be used as `extends` targets. The `isDir` heuristic in `src/loader.ts` reads:

```ts
const isDir = !ext || ext === basename(source); /* #71 */
```

For `foo.bar.baz`, `extname` returns `.baz` and `basename` returns `foo.bar.baz`, so the condition `ext === basename(source)` is `false` — the path is misclassified as a file, not a directory. The resolved `cwd` is then set to `dirname(source)` instead of `source` itself, and the config lookup targets the wrong directory.

## Fix

As suggested by @pi0 in the issue, use `fs.statSync` to check if the resolved path is actually a directory when it exists on disk, and only fall back to the extension-based heuristic for paths that don't exist yet (remote URLs, npm packages after transformation, etc.):

```ts
// Before
const isDir = !ext || ext === basename(source); /* #71 */

// After
const resolvedPath = resolve(options.cwd!, source);
const isDir = existsSync(resolvedPath)
  ? statSync(resolvedPath).isDirectory()
  : !ext || ext === basename(source); /* #71 */
```

`statSync` is imported from `node:fs` alongside the existing `existsSync` import.

## Tests

- Added `test/fixture/my.dotted.layer/.config/test.config.json5` — a config layer inside a multi-dot directory.
- Added `test/fixture/multi-dot-extends/test.config.json5` — a config that extends from `../my.dotted.layer`.
- Added a regression test in `test/loader.test.ts` verifying the layer is resolved and its config is merged correctly.

## Verification

- `vitest run` — 16/16 ✅, 3 test files
- `oxlint` — 0 warnings, 0 errors ✅
- `oxfmt` — clean on changed files ✅ (repo-wide pre-existing failures unrelated to this PR)
- `pnpm build` — clean ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory detection during configuration loading: resolved-path checks and safer handling of missing paths ensure directories with multiple dots are correctly recognized and config inheritance resolves properly.

* **Tests**
  * Added fixtures and tests verifying configuration inheritance and merging when extending from directories whose names contain multiple dots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->