### PR TITLE
feat: add `pickExport` option for named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ const { config } = await loadConfig({
 
 ### `pickExport`
 
-Named export(s) to use as the config root. Tries each name in order and returns the first one that is exported. Falls back to `mod.default || mod` if none match.
+Named exports to use as the config root. Tries each name in order and returns the first one that is exported. Falls back to `mod.default || mod` if none match.
 
 Ignored when a custom [`resolveModule`](#resolvemodule) is provided. Only applies to JS/TS module loading; non-module formats (YAML, TOML, JSON5, JSONC) are unaffected.
 
@@ -236,7 +236,7 @@ export default { foo: false };
 
 ```js
 const { config } = await loadConfig({
-  pickExport: "config", // or ["config", "myConfig"]
+  pickExport: ["config", "myConfig"],
 });
 // → { foo: true }
 ```

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ const { config } = await loadConfig({
 
 ### `configExport`
 
-Named export(s) to use as the config root, in priority order. Tries each name first and falls back to `mod.default || mod`.
+Named export(s) to use as the config root, in priority order, or a callback for full control. In all forms, falls back to `mod.default || mod` if nothing is picked.
 
 Ignored when a custom [`resolveModule`](#resolvemodule) is provided.
 
@@ -237,6 +237,14 @@ const { config } = await loadConfig({
   configExport: "config", // or ["config", "myConfig"]
 });
 // → { foo: true }
+```
+
+**Callback form:** Pick the export dynamically. Return `undefined` to fall through to `mod.default || mod`.
+
+```js
+const { config } = await loadConfig({
+  configExport: (mod) => mod[process.env.MODE],
+});
 ```
 
 ### `giget`

--- a/README.md
+++ b/README.md
@@ -218,6 +218,27 @@ const { config } = await loadConfig({
 });
 ```
 
+### `configExport`
+
+Named export(s) to use as the config root, in priority order. Tries each name first and falls back to `mod.default || mod`.
+
+Ignored when a custom [`resolveModule`](#resolvemodule) is provided.
+
+**Example:** Prefer a `config` named export, fall back to default:
+
+```ts
+// my.config.ts
+export const config = { foo: true };
+export default { foo: false };
+```
+
+```js
+const { config } = await loadConfig({
+  configExport: "config", // or ["config", "myConfig"]
+});
+// → { foo: true }
+```
+
 ### `giget`
 
 Options passed to [unjs/giget](https://github.com/unjs/giget) when extending layer from git source.

--- a/README.md
+++ b/README.md
@@ -220,12 +220,11 @@ const { config } = await loadConfig({
 
 ### `pickExport`
 
-Named export(s) to use as the config root, or a callback that picks one.
-
-- `string` / `string[]`: tries each name in order and returns the first one that is exported. Falls back to `mod.default || mod` if none match.
-- `(mod) => any`: full control — the returned value is used as-is, with no fallback.
+Named export(s) to use as the config root. Tries each name in order and returns the first one that is exported. Falls back to `mod.default || mod` if none match.
 
 Ignored when a custom [`resolveModule`](#resolvemodule) is provided. Only applies to JS/TS module loading; non-module formats (YAML, TOML, JSON5, JSONC) are unaffected.
+
+For dynamic picking, use [`resolveModule`](#resolvemodule) instead.
 
 **Example:** Prefer a `config` named export, fall back to default:
 
@@ -240,14 +239,6 @@ const { config } = await loadConfig({
   pickExport: "config", // or ["config", "myConfig"]
 });
 // → { foo: true }
-```
-
-**Callback form:** Pick the export dynamically. The returned value is final.
-
-```js
-const { config } = await loadConfig({
-  pickExport: (mod) => mod[process.env.MODE] ?? mod.default,
-});
 ```
 
 ### `giget`

--- a/README.md
+++ b/README.md
@@ -218,11 +218,14 @@ const { config } = await loadConfig({
 });
 ```
 
-### `configExport`
+### `pickExport`
 
-Named export(s) to use as the config root, in priority order, or a callback for full control. In all forms, falls back to `mod.default || mod` if nothing is picked.
+Named export(s) to use as the config root, or a callback that picks one.
 
-Ignored when a custom [`resolveModule`](#resolvemodule) is provided.
+- `string` / `string[]`: tries each name in order and returns the first one that is exported. Falls back to `mod.default || mod` if none match.
+- `(mod) => any`: full control — the returned value is used as-is, with no fallback.
+
+Ignored when a custom [`resolveModule`](#resolvemodule) is provided. Only applies to JS/TS module loading; non-module formats (YAML, TOML, JSON5, JSONC) are unaffected.
 
 **Example:** Prefer a `config` named export, fall back to default:
 
@@ -234,16 +237,16 @@ export default { foo: false };
 
 ```js
 const { config } = await loadConfig({
-  configExport: "config", // or ["config", "myConfig"]
+  pickExport: "config", // or ["config", "myConfig"]
 });
 // → { foo: true }
 ```
 
-**Callback form:** Pick the export dynamically. Return `undefined` to fall through to `mod.default || mod`.
+**Callback form:** Pick the export dynamically. The returned value is final.
 
 ```js
 const { config } = await loadConfig({
-  configExport: (mod) => mod[process.env.MODE],
+  pickExport: (mod) => mod[process.env.MODE] ?? mod.default,
 });
 ```
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -384,15 +384,11 @@ async function resolveConfig<
     const contents = await readFile(res.configFile!, "utf8");
     res.config = asyncLoader(contents);
   } else {
-    const exportNames =
-      typeof options.pickExport === "string"
-        ? [options.pickExport]
-        : options.pickExport;
     const _resolveModule =
       options.resolveModule ||
       ((mod: any) => {
-        if (exportNames) {
-          for (const name of exportNames) {
+        if (options.pickExport) {
+          for (const name of options.pickExport) {
             if (name in mod) return mod[name];
           }
         }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -384,14 +384,16 @@ async function resolveConfig<
     const contents = await readFile(res.configFile!, "utf8");
     res.config = asyncLoader(contents);
   } else {
+    const exportNames = options.configExport
+      ? Array.isArray(options.configExport)
+        ? options.configExport
+        : [options.configExport]
+      : undefined;
     const _resolveModule =
       options.resolveModule ||
       ((mod: any) => {
-        if (options.configExport) {
-          const names = Array.isArray(options.configExport)
-            ? options.configExport
-            : [options.configExport];
-          for (const name of names) {
+        if (exportNames) {
+          for (const name of exportNames) {
             if (mod[name] !== undefined) return mod[name];
           }
         }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -384,15 +384,20 @@ async function resolveConfig<
     const contents = await readFile(res.configFile!, "utf8");
     res.config = asyncLoader(contents);
   } else {
-    const exportNames = options.configExport
-      ? Array.isArray(options.configExport)
-        ? options.configExport
-        : [options.configExport]
-      : undefined;
+    const _configExport = options.configExport;
+    const exportNames =
+      typeof _configExport === "string"
+        ? [_configExport]
+        : Array.isArray(_configExport)
+          ? _configExport
+          : undefined;
     const _resolveModule =
       options.resolveModule ||
       ((mod: any) => {
-        if (exportNames) {
+        if (typeof _configExport === "function") {
+          const picked = _configExport(mod);
+          if (picked !== undefined) return picked;
+        } else if (exportNames) {
           for (const name of exportNames) {
             if (mod[name] !== undefined) return mod[name];
           }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -384,7 +384,19 @@ async function resolveConfig<
     const contents = await readFile(res.configFile!, "utf8");
     res.config = asyncLoader(contents);
   } else {
-    const _resolveModule = options.resolveModule || ((mod: any) => mod.default || mod);
+    const _resolveModule =
+      options.resolveModule ||
+      ((mod: any) => {
+        if (options.configExport) {
+          const names = Array.isArray(options.configExport)
+            ? options.configExport
+            : [options.configExport];
+          for (const name of names) {
+            if (mod[name] !== undefined) return mod[name];
+          }
+        }
+        return mod.default || mod;
+      });
     if (options.import) {
       res.config = _resolveModule(await options.import(res.configFile!)) as T;
     } else {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -384,22 +384,22 @@ async function resolveConfig<
     const contents = await readFile(res.configFile!, "utf8");
     res.config = asyncLoader(contents);
   } else {
-    const _configExport = options.configExport;
+    const _pickExport = options.pickExport;
     const exportNames =
-      typeof _configExport === "string"
-        ? [_configExport]
-        : Array.isArray(_configExport)
-          ? _configExport
+      typeof _pickExport === "string"
+        ? [_pickExport]
+        : Array.isArray(_pickExport)
+          ? _pickExport
           : undefined;
     const _resolveModule =
       options.resolveModule ||
       ((mod: any) => {
-        if (typeof _configExport === "function") {
-          const picked = _configExport(mod);
-          if (picked !== undefined) return picked;
-        } else if (exportNames) {
+        if (typeof _pickExport === "function") {
+          return _pickExport(mod);
+        }
+        if (exportNames) {
           for (const name of exportNames) {
-            if (mod[name] !== undefined) return mod[name];
+            if (name in mod) return mod[name];
           }
         }
         return mod.default || mod;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -384,19 +384,13 @@ async function resolveConfig<
     const contents = await readFile(res.configFile!, "utf8");
     res.config = asyncLoader(contents);
   } else {
-    const _pickExport = options.pickExport;
     const exportNames =
-      typeof _pickExport === "string"
-        ? [_pickExport]
-        : Array.isArray(_pickExport)
-          ? _pickExport
-          : undefined;
+      typeof options.pickExport === "string"
+        ? [options.pickExport]
+        : options.pickExport;
     const _resolveModule =
       options.resolveModule ||
       ((mod: any) => {
-        if (typeof _pickExport === "function") {
-          return _pickExport(mod);
-        }
         if (exportNames) {
           for (const name of exportNames) {
             if (name in mod) return mod[name];

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,7 +146,7 @@ export interface LoadConfigOptions<
   resolveModule?: (mod: any) => any;
 
   /**
-   * Named export(s) to use as the config root. Tries each name in order and returns
+   * Named exports to use as the config root. Tries each name in order and returns
    * the first one that is exported. Falls back to `mod.default || mod` if none match.
    *
    * Ignored when a custom `resolveModule` is provided. Only applies to JS/TS module
@@ -157,11 +157,11 @@ export interface LoadConfigOptions<
    * @example
    * ```ts
    * // Loads `mod.config` if exported, else falls back to default export
-   * loadConfig({ pickExport: "config" })
+   * loadConfig({ pickExport: ["config"] })
    * loadConfig({ pickExport: ["config", "myConfig"] })
    * ```
    */
-  pickExport?: string | string[];
+  pickExport?: string[];
 
   giget?: false | DownloadTemplateOptions;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,29 +132,34 @@ export interface LoadConfigOptions<
   /** Custom import function used to load configuration files */
   import?: (id: string) => Promise<unknown>;
 
-  /** Custom resolver for picking which export to use from the loaded module. Default: `(mod) => mod.default || mod` */
+  /**
+   * Custom resolver for picking which export to use from the loaded module.
+   * Overrides `pickExport` when set.
+   *
+   * Default: a resolver honoring `pickExport` (if any), else `mod.default || mod`.
+   */
   resolveModule?: (mod: any) => any;
 
   /**
-   * Named export(s) to use as the config root, in priority order, or a callback
-   * that picks an export from the loaded module.
+   * Named export(s) to use as the config root, or a callback that picks one.
    *
-   * - `string` / `string[]`: tries each name on the module and returns the first defined one.
-   * - `(mod) => any`: full control — return the chosen value, or `undefined` to fall through.
+   * - `string` / `string[]`: tries each name on the module in order and returns
+   *   the first one that is exported. Falls back to `mod.default || mod` if none match.
+   * - `(mod) => any`: full control — the returned value is used as-is, with no fallback.
    *
-   * In all forms, falls back to `mod.default || mod` if nothing is picked.
-   * Ignored when a custom `resolveModule` is provided.
+   * Ignored when a custom `resolveModule` is provided. Only applies to JS/TS module
+   * loading; non-module formats (YAML, TOML, JSON5, JSONC) are unaffected.
    *
    * @example
    * ```ts
-   * // Loads `mod.config` if defined, else falls back to default export
-   * loadConfig({ configExport: "config" })
+   * // Loads `mod.config` if exported, else falls back to default export
+   * loadConfig({ pickExport: "config" })
    *
-   * // Pick dynamically based on env
-   * loadConfig({ configExport: (mod) => mod[process.env.MODE!] })
+   * // Pick dynamically based on env (return is final)
+   * loadConfig({ pickExport: (mod) => mod[process.env.MODE!] ?? mod.default })
    * ```
    */
-  configExport?: string | string[] | ((mod: any) => any);
+  pickExport?: string | string[] | ((mod: any) => any);
 
   giget?: false | DownloadTemplateOptions;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,20 @@ export interface LoadConfigOptions<
   /** Custom resolver for picking which export to use from the loaded module. Default: `(mod) => mod.default || mod` */
   resolveModule?: (mod: any) => any;
 
+  /**
+   * Named export(s) to use as the config root, in priority order.
+   *
+   * If set, the loader tries these named exports first and falls back to `mod.default || mod`.
+   * Ignored when a custom `resolveModule` is provided.
+   *
+   * @example
+   * ```ts
+   * // Loads `mod.config` if defined, else falls back to default export
+   * loadConfig({ configExport: "config" })
+   * ```
+   */
+  configExport?: string | string[];
+
   giget?: false | DownloadTemplateOptions;
 
   merger?: (...sources: Array<T | null | undefined>) => T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,32 +134,34 @@ export interface LoadConfigOptions<
 
   /**
    * Custom resolver for picking which export to use from the loaded module.
-   * Overrides `pickExport` when set.
+   * Overrides `pickExport` when set. Use this for full programmatic control.
    *
    * Default: a resolver honoring `pickExport` (if any), else `mod.default || mod`.
+   *
+   * @example
+   * ```ts
+   * loadConfig({ resolveModule: (mod) => mod[process.env.MODE!] ?? mod.default })
+   * ```
    */
   resolveModule?: (mod: any) => any;
 
   /**
-   * Named export(s) to use as the config root, or a callback that picks one.
-   *
-   * - `string` / `string[]`: tries each name on the module in order and returns
-   *   the first one that is exported. Falls back to `mod.default || mod` if none match.
-   * - `(mod) => any`: full control — the returned value is used as-is, with no fallback.
+   * Named export(s) to use as the config root. Tries each name in order and returns
+   * the first one that is exported. Falls back to `mod.default || mod` if none match.
    *
    * Ignored when a custom `resolveModule` is provided. Only applies to JS/TS module
    * loading; non-module formats (YAML, TOML, JSON5, JSONC) are unaffected.
+   *
+   * For dynamic picking, use `resolveModule` instead.
    *
    * @example
    * ```ts
    * // Loads `mod.config` if exported, else falls back to default export
    * loadConfig({ pickExport: "config" })
-   *
-   * // Pick dynamically based on env (return is final)
-   * loadConfig({ pickExport: (mod) => mod[process.env.MODE!] ?? mod.default })
+   * loadConfig({ pickExport: ["config", "myConfig"] })
    * ```
    */
-  pickExport?: string | string[] | ((mod: any) => any);
+  pickExport?: string | string[];
 
   giget?: false | DownloadTemplateOptions;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,18 +136,25 @@ export interface LoadConfigOptions<
   resolveModule?: (mod: any) => any;
 
   /**
-   * Named export(s) to use as the config root, in priority order.
+   * Named export(s) to use as the config root, in priority order, or a callback
+   * that picks an export from the loaded module.
    *
-   * If set, the loader tries these named exports first and falls back to `mod.default || mod`.
+   * - `string` / `string[]`: tries each name on the module and returns the first defined one.
+   * - `(mod) => any`: full control — return the chosen value, or `undefined` to fall through.
+   *
+   * In all forms, falls back to `mod.default || mod` if nothing is picked.
    * Ignored when a custom `resolveModule` is provided.
    *
    * @example
    * ```ts
    * // Loads `mod.config` if defined, else falls back to default export
    * loadConfig({ configExport: "config" })
+   *
+   * // Pick dynamically based on env
+   * loadConfig({ configExport: (mod) => mod[process.env.MODE!] })
    * ```
    */
-  configExport?: string | string[];
+  configExport?: string | string[] | ((mod: any) => any);
 
   giget?: false | DownloadTemplateOptions;
 

--- a/test/fixture/named-export/config.ts
+++ b/test/fixture/named-export/config.ts
@@ -1,0 +1,7 @@
+export const config = {
+  fromNamedExport: true,
+};
+
+export default {
+  fromDefaultExport: true,
+};

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -378,15 +378,15 @@ describe("loader", () => {
   it("loads named export when pickExport is set", async () => {
     const loaded = await loadConfig({
       cwd: r("./fixture/named-export"),
-      pickExport: "config",
+      pickExport: ["config"],
     });
     expect(loaded.config).toEqual({ fromNamedExport: true });
   });
 
-  it("falls back to default export when pickExport name is missing", async () => {
+  it("falls back to default export when pickExport names are missing", async () => {
     const loaded = await loadConfig({
       cwd: r("./fixture/named-export"),
-      pickExport: "missing",
+      pickExport: ["missing"],
     });
     expect(loaded.config).toEqual({ fromDefaultExport: true });
   });

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -375,6 +375,30 @@ describe("loader", () => {
     });
   });
 
+  it("loads named export when configExport is set", async () => {
+    const loaded = await loadConfig({
+      cwd: r("./fixture/named-export"),
+      configExport: "config",
+    });
+    expect(loaded.config).toEqual({ fromNamedExport: true });
+  });
+
+  it("falls back to default export when configExport name is missing", async () => {
+    const loaded = await loadConfig({
+      cwd: r("./fixture/named-export"),
+      configExport: "missing",
+    });
+    expect(loaded.config).toEqual({ fromDefaultExport: true });
+  });
+
+  it("tries multiple configExport names in priority order", async () => {
+    const loaded = await loadConfig({
+      cwd: r("./fixture/named-export"),
+      configExport: ["missing", "config"],
+    });
+    expect(loaded.config).toEqual({ fromNamedExport: true });
+  });
+
   it("try reproduce error with index.js on root importing jsx/tsx", async () => {
     await loadConfig({
       name: "test",

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -375,44 +375,36 @@ describe("loader", () => {
     });
   });
 
-  it("loads named export when configExport is set", async () => {
+  it("loads named export when pickExport is set", async () => {
     const loaded = await loadConfig({
       cwd: r("./fixture/named-export"),
-      configExport: "config",
+      pickExport: "config",
     });
     expect(loaded.config).toEqual({ fromNamedExport: true });
   });
 
-  it("falls back to default export when configExport name is missing", async () => {
+  it("falls back to default export when pickExport name is missing", async () => {
     const loaded = await loadConfig({
       cwd: r("./fixture/named-export"),
-      configExport: "missing",
+      pickExport: "missing",
     });
     expect(loaded.config).toEqual({ fromDefaultExport: true });
   });
 
-  it("tries multiple configExport names in priority order", async () => {
+  it("tries multiple pickExport names in priority order", async () => {
     const loaded = await loadConfig({
       cwd: r("./fixture/named-export"),
-      configExport: ["missing", "config"],
+      pickExport: ["missing", "config"],
     });
     expect(loaded.config).toEqual({ fromNamedExport: true });
   });
 
-  it("supports configExport as a callback for full control", async () => {
+  it("uses pickExport callback return as-is", async () => {
     const loaded = await loadConfig({
       cwd: r("./fixture/named-export"),
-      configExport: (mod) => mod.config,
+      pickExport: (mod) => mod.config,
     });
     expect(loaded.config).toEqual({ fromNamedExport: true });
-  });
-
-  it("falls back to default export when configExport callback returns undefined", async () => {
-    const loaded = await loadConfig({
-      cwd: r("./fixture/named-export"),
-      configExport: () => undefined,
-    });
-    expect(loaded.config).toEqual({ fromDefaultExport: true });
   });
 
   it("try reproduce error with index.js on root importing jsx/tsx", async () => {

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -399,6 +399,22 @@ describe("loader", () => {
     expect(loaded.config).toEqual({ fromNamedExport: true });
   });
 
+  it("supports configExport as a callback for full control", async () => {
+    const loaded = await loadConfig({
+      cwd: r("./fixture/named-export"),
+      configExport: (mod) => mod.config,
+    });
+    expect(loaded.config).toEqual({ fromNamedExport: true });
+  });
+
+  it("falls back to default export when configExport callback returns undefined", async () => {
+    const loaded = await loadConfig({
+      cwd: r("./fixture/named-export"),
+      configExport: () => undefined,
+    });
+    expect(loaded.config).toEqual({ fromDefaultExport: true });
+  });
+
   it("try reproduce error with index.js on root importing jsx/tsx", async () => {
     await loadConfig({
       name: "test",

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -399,14 +399,6 @@ describe("loader", () => {
     expect(loaded.config).toEqual({ fromNamedExport: true });
   });
 
-  it("uses pickExport callback return as-is", async () => {
-    const loaded = await loadConfig({
-      cwd: r("./fixture/named-export"),
-      pickExport: (mod) => mod.config,
-    });
-    expect(loaded.config).toEqual({ fromNamedExport: true });
-  });
-
   it("try reproduce error with index.js on root importing jsx/tsx", async () => {
     await loadConfig({
       name: "test",


### PR DESCRIPTION
Adds a `pickExport` option to load named export(s) (e.g. `config`) from config files, falling back to `mod.default || mod`. Closes #244.

```ts
loadConfig({ pickExport: "config" })
loadConfig({ pickExport: ["config", "myConfig"] })
```

Ignored when a custom `resolveModule` is provided. Only applies to JS/TS module loading; non-module formats (YAML, TOML, JSON5, JSONC) are unaffected.

For dynamic / programmatic picking, use the existing `resolveModule` option:

```ts
loadConfig({ resolveModule: (mod) => mod[process.env.MODE!] ?? mod.default })
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pickExport` option to select named exports from JS/TS modules as the config root
  * Added `resolveModule` option for custom module resolution

* **Breaking Changes**
  * Removed `import` option from LoadConfigOptions

* **Documentation**
  * Updated README with detailed examples and behavior documentation for new options

* **Tests**
  * Added test coverage for pickExport functionality across multiple scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->