### PR TITLE
test(loader): strengthen multi-dot dir regression with merged config assertion

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -353,8 +353,7 @@ async function resolveConfig<
   // Import from local fs
   const ext = extname(source);
   const resolvedPath = resolve(options.cwd!, source);
-  const isDir = _isDirectory(resolvedPath)
-    ?? (!ext || ext === basename(source)); /* #71 */
+  const isDir = _isDirectory(resolvedPath) ?? (!ext || ext === basename(source)); /* #71 */
   const cwd = resolve(options.cwd!, isDir ? source : dirname(source));
   if (isDir) {
     source = options.configFile!;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -353,9 +353,8 @@ async function resolveConfig<
   // Import from local fs
   const ext = extname(source);
   const resolvedPath = resolve(options.cwd!, source);
-  const isDir = existsSync(resolvedPath)
-    ? statSync(resolvedPath).isDirectory()
-    : !ext || ext === basename(source); /* #71 */
+  const isDir = _isDirectory(resolvedPath)
+    ?? (!ext || ext === basename(source)); /* #71 */
   const cwd = resolve(options.cwd!, isDir ? source : dirname(source));
   if (isDir) {
     source = options.configFile!;
@@ -453,4 +452,13 @@ function tryResolve(id: string, options: LoadConfigOptions<any, any>) {
     cache: false,
   });
   return res ? normalize(res) : undefined;
+}
+
+/** Returns `true`/`false` if the path exists, `null` if it doesn't. */
+function _isDirectory(path: string): boolean | null {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return null;
+  }
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import { homedir } from "node:os";
@@ -350,7 +350,10 @@ async function resolveConfig<
 
   // Import from local fs
   const ext = extname(source);
-  const isDir = !ext || ext === basename(source); /* #71 */
+  const resolvedPath = resolve(options.cwd!, source);
+  const isDir = existsSync(resolvedPath)
+    ? statSync(resolvedPath).isDirectory()
+    : !ext || ext === basename(source); /* #71 */
   const cwd = resolve(options.cwd!, isDir ? source : dirname(source));
   if (isDir) {
     source = options.configFile!;

--- a/test/fixture/multi-dot-extends/test.config.json5
+++ b/test/fixture/multi-dot-extends/test.config.json5
@@ -1,0 +1,4 @@
+{
+  extends: ["../my.dotted.layer"],
+  baseKey: true,
+}

--- a/test/fixture/my.dotted.layer/.config/test.config.json5
+++ b/test/fixture/my.dotted.layer/.config/test.config.json5
@@ -1,0 +1,3 @@
+{
+  multiDotLayer: true,
+}

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -377,4 +377,20 @@ describe("loader", () => {
       cwd: r("./fixture/jsx"),
     });
   });
+
+  it("extends from a directory whose name contains multiple dots (#278)", async () => {
+    const { config, layers } = await loadConfig({
+      name: "test",
+      cwd: r("./fixture/multi-dot-extends"),
+      extend: {
+        extendKey: "extends",
+      },
+    });
+    // The multi-dot dir should be resolved as a directory, not a file
+    const multiDotLayer = layers?.find((l) => l.cwd && l.cwd.includes("my.dotted.layer"));
+    expect(multiDotLayer).toBeDefined();
+    expect(multiDotLayer?.config).toMatchObject({ multiDotLayer: true });
+    // Base config key should still be present (merged)
+    expect(config).toMatchObject({ baseKey: true });
+  });
 });

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -390,7 +390,7 @@ describe("loader", () => {
     const multiDotLayer = layers?.find((l) => l.cwd && l.cwd.includes("my.dotted.layer"));
     expect(multiDotLayer).toBeDefined();
     expect(multiDotLayer?.config).toMatchObject({ multiDotLayer: true });
-    // Base config key should still be present (merged)
-    expect(config).toMatchObject({ baseKey: true });
+    // Base config key and extended layer key should both be present (merged)
+    expect(config).toMatchObject({ baseKey: true, multiDotLayer: true });
   });
 });


### PR DESCRIPTION
## Problem

The existing regression test for multi-dot directory extends only asserted that the `multiDotLayer` key was present inside the resolved layer object itself:

```ts
expect(multiDotLayer?.config).toMatchObject({ multiDotLayer: true });
// Base config key should still be present (merged)
expect(config).toMatchObject({ baseKey: true });
```

The comment said "base config key should still be present (merged)" but the assertion stopped there. It didn't verify that the extended layer's own key (`multiDotLayer: true`) was carried through into the final merged `config` — which is the actual point of the regression test. A bug that drops the extended layer value from the merged result would pass this test.

## Fix

Add `multiDotLayer: true` to the top-level `config` assertion so both the base key and the extended layer key must survive the merge:

```ts
expect(config).toMatchObject({ baseKey: true, multiDotLayer: true });
```

Also updated the comment to reflect what is actually being checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory detection reliability for configuration file extends, enabling proper resolution of directories with multiple dots in their names.

* **Tests**
  * Added test coverage for multi-dot directory name configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->