### PR TITLE
fix: install layer deps with `ignoreWorkspace`

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -336,8 +336,15 @@ async function resolveConfig<
     }
     const cloned = await downloadTemplate(source, {
       dir: cloneDir,
-      install: sourceOptions.install,
-      force: sourceOptions.install,
+      // install the cloned layer in isolation as it lives in `.c12/<name>` and
+      // is not a workspace member (unjs/c12#128)
+      install:
+        typeof sourceOptions.install === "object"
+          ? { ignoreWorkspace: true, ...sourceOptions.install }
+          : sourceOptions.install
+            ? { ignoreWorkspace: true }
+            : false,
+      force: Boolean(sourceOptions.install),
       auth: sourceOptions.auth,
       ...options.giget,
       ...sourceOptions.giget,

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,9 +48,12 @@ export interface SourceOptions<
   /**
    * Install dependencies after cloning
    *
+   * Pass `true` to install with c12's defaults (`ignoreWorkspace: true`), or pass an object
+   * to forward arbitrary nypm install options.
+   *
    * @see https://nypm.unjs.io
    */
-  install?: boolean;
+  install?: NonNullable<DownloadTemplateOptions["install"]>;
 
   /**
    * Token for cloning private sources

--- a/test/loader-giget.test.ts
+++ b/test/loader-giget.test.ts
@@ -1,0 +1,87 @@
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { normalize } from "pathe";
+import { loadConfig } from "../src/index.ts";
+
+const r = (path: string) => normalize(fileURLToPath(new URL(path, import.meta.url)));
+
+const downloadTemplate = vi.hoisted(() => vi.fn());
+
+vi.mock("giget", () => ({
+  downloadTemplate,
+}));
+
+// Regression coverage for unjs/c12#128 & nuxt/nuxt#33382: when a layer is
+// extended with `install: true` from inside a pnpm workspace, c12 must ask
+// giget+nypm to install in isolation (`--ignore-workspace`), otherwise pnpm
+// escalates to the consumer's `pnpm-workspace.yaml` and re-runs the
+// consumer's own `postinstall`, which can re-enter c12 and recurse.
+describe("loader: giget install options", () => {
+  beforeEach(() => {
+    downloadTemplate.mockReset();
+    downloadTemplate.mockImplementation(async () => ({
+      dir: r("./fixture/_github"),
+      source: "github:unjs/c12/test/fixture",
+      name: "_github",
+      tar: "",
+    }));
+  });
+
+  it("forwards ignoreWorkspace when sourceOptions.install is true", async () => {
+    await loadConfig({
+      name: "test",
+      cwd: r("./fixture/new_dir"),
+      overrides: {
+        extends: [["github:unjs/c12/test/fixture", { install: true }]],
+      },
+    });
+
+    expect(downloadTemplate).toHaveBeenCalledTimes(1);
+    const opts = downloadTemplate.mock.calls[0]![1];
+    expect(opts.install).toEqual({ ignoreWorkspace: true });
+    expect(opts.force).toBe(true);
+  });
+
+  it("passes install: false when sourceOptions.install is falsy", async () => {
+    await loadConfig({
+      name: "test",
+      cwd: r("./fixture/new_dir"),
+      overrides: {
+        extends: ["github:unjs/c12/test/fixture"],
+      },
+    });
+
+    expect(downloadTemplate).toHaveBeenCalledTimes(1);
+    const opts = downloadTemplate.mock.calls[0]![1];
+    expect(opts.install).toBe(false);
+  });
+
+  it("merges sourceOptions.install object on top of ignoreWorkspace default", async () => {
+    await loadConfig({
+      name: "test",
+      cwd: r("./fixture/new_dir"),
+      overrides: {
+        extends: [["github:unjs/c12/test/fixture", { install: { silent: true } }]],
+      },
+    });
+
+    expect(downloadTemplate).toHaveBeenCalledTimes(1);
+    const opts = downloadTemplate.mock.calls[0]![1];
+    expect(opts.install).toEqual({ ignoreWorkspace: true, silent: true });
+    expect(opts.force).toBe(true);
+  });
+
+  it("lets sourceOptions.install opt back in to workspace-aware install", async () => {
+    await loadConfig({
+      name: "test",
+      cwd: r("./fixture/new_dir"),
+      overrides: {
+        extends: [["github:unjs/c12/test/fixture", { install: { ignoreWorkspace: false } }]],
+      },
+    });
+
+    expect(downloadTemplate).toHaveBeenCalledTimes(1);
+    const opts = downloadTemplate.mock.calls[0]![1];
+    expect(opts.install).toEqual({ ignoreWorkspace: false });
+  });
+});


### PR DESCRIPTION
resolves nuxt/nuxt#33382
resolves  unjs/c12#128

this defaults `ignoreWorkspace` to true as it's not part of the workspace (it's cloned in `.c12` and is a separate install).

I thought this was a better fix than doing it directly in `nuxt` but of course we can move it there if you prefer @pi0 🙏 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced template installation configuration to support granular control over install options when cloning templates.
  * Install behavior now defaults to isolated workspace mode for cloned templates, with ability to customize via configuration objects.

* **Tests**
  * Added comprehensive test coverage for template installation configuration handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/c12/pull/318)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->