### PR TITLE
fix: support extending a non-extensible config layer

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -414,6 +414,14 @@ async function resolveConfig<
     );
   }
 
+  // The loaded config can be a non-extensible object, e.g. a native module
+  // namespace (`[Module: null prototype] {}`) or a frozen default export.
+  // c12 mutates the config later on (adds `_layers`, strips `$meta` and
+  // extend keys), so ensure we own a mutable copy.
+  if (res.config && typeof res.config === "object" && !Object.isExtensible(res.config)) {
+    res.config = { ...res.config };
+  }
+
   // Extend env specific config
   if (options.envName) {
     const envConfig = {

--- a/test/fixture/frozen-extends/frozen-base.mjs
+++ b/test/fixture/frozen-extends/frozen-base.mjs
@@ -1,0 +1,3 @@
+// A non-extensible default export, e.g. as produced by a native ESM import
+// of a frozen config object.
+export default Object.freeze({ frozenBase: true, shared: "base" });

--- a/test/fixture/frozen-extends/test.config.mjs
+++ b/test/fixture/frozen-extends/test.config.mjs
@@ -1,0 +1,4 @@
+export default {
+  extends: ["./frozen-base.mjs"],
+  app: true,
+};

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -337,6 +337,20 @@ describe("loader", () => {
     expect(Object.keys(baseLayerConfig.config!)).toContain("$env");
   });
 
+  // https://github.com/unjs/c12/issues/205
+  it("extends a non-extensible (frozen) layer", async () => {
+    const { config } = await loadConfig({
+      name: "test",
+      cwd: r("./fixture/frozen-extends"),
+    });
+
+    expect(config).toMatchObject({
+      app: true,
+      frozenBase: true,
+      shared: "base",
+    });
+  });
+
   it("no config loaded and configFileRequired is default setting", async () => {
     await expect(
       loadConfig({


### PR DESCRIPTION
Fixes #205.

### Problem

Loading a config that `extends` a layer whose resolved config is a **non-extensible** object throws:

```
TypeError: Cannot add property _layers, object is not extensible
```

This happens when an extended layer's config is e.g. a native ESM module namespace (`[Module: null prototype] {}`) or a frozen default export (`export default Object.freeze({ ... })`).

### Cause

`c12` mutates the loaded config in place — `extendConfig` adds `_layers` (`src/loader.ts`), and `resolveConfig` strips `$meta` and the extend keys. When the config object is frozen / non-extensible, the very first mutation throws.

### Fix

After the config is loaded (and any config function resolved), take a mutable shallow copy when the object is not extensible:

```ts
if (res.config && typeof res.config === "object" && !Object.isExtensible(res.config)) {
  res.config = { ...res.config };
}
```

### Tests

Added a `frozen-extends` fixture (`test.config.mjs` extending a `Object.freeze(...)` default export) and a test asserting the merged config loads. It throws the exact error without this change and passes with it; the full suite (20 tests) stays green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Config resolution now properly handles non-extensible (frozen) objects by creating mutable copies before applying internal modifications.

* **Tests**
  * Added regression test verifying correct behavior when extending frozen configuration layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->