### PR TITLE
feat(loader): add onResolved hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,32 @@ Context object passed to dynamic config functions.
 
 You can define a custom function that resolves the config.
 
+### `onResolved`
+
+Runs after all config sources and layers are merged, with the same `{ config, layers, ... }` object returned by `loadConfig`.
+
+Merging can retain nested references between `config` and `layers`. For a single load, clone `config` after loading:
+
+```js
+import { klona } from "klona";
+
+const loaded = await loadConfig({});
+const config = klona(loaded.config);
+```
+
+`klona` is only an example. It does not handle circular references, and stateful class instances may need a custom clone.
+
+With `watchConfig`, use the hook to clone after every reload:
+
+```js
+const watcher = await watchConfig({
+  onResolved: (resolved) => ({
+    ...resolved,
+    config: klona(resolved.config),
+  }),
+});
+```
+
 ### `configFileRequired`
 
 If this option is set to `true`, loader fails if the main config file does not exists.

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -211,7 +211,7 @@ export async function loadConfig<
   }
 
   // Return resolved config
-  return r;
+  return (await options.onResolved?.(r)) ?? r;
 }
 
 async function extendConfig<

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,9 @@ export interface LoadConfigOptions<
   /** Context passed to config functions */
   context?: ConfigFunctionContext;
 
+  /** Runs after all config sources and layers are merged. */
+  onResolved?: (resolved: ResolvedConfig<T, MT>) => MaybePromise<ResolvedConfig<T, MT> | void>;
+
   resolve?: (
     id: string,
     options: LoadConfigOptions<T, MT>,

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -306,6 +306,33 @@ describe("loader", () => {
     `);
   });
 
+  it("calls onResolved with the resolved result", async () => {
+    type Config = {
+      extends?: string[];
+      nested?: { value: string; transformed?: boolean };
+    };
+    const { config, layers } = await loadConfig<Config>({
+      cwd: r("./fixture/new_dir"),
+      name: "missing",
+      rcFile: false,
+      overrides: { extends: ["virtual"] },
+      resolve: (source) =>
+        source === "virtual" ? { source, config: { nested: { value: "layer" } } } : undefined,
+      onResolved: async (resolved) => ({
+        ...resolved,
+        config: {
+          ...resolved.config,
+          nested: { ...resolved.config.nested!, transformed: true },
+        },
+      }),
+    });
+    const layer = layers!.find((layer) => layer.source === "virtual")!;
+
+    expect(config.nested).toEqual({ value: "layer", transformed: true });
+    expect(layer.config!.nested).toEqual({ value: "layer" });
+    expect(config.nested).not.toBe(layer.config!.nested);
+  });
+
   it("omit$Keys", async () => {
     const { config, layers } = await loadConfig({
       name: "test",


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312"
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

`loadConfig` can retain nested references between `config` and `layers`, so mutating `config` can also mutate a layer.

```js
const loaded = await loadConfig({
  onResolved: resolved => ({
    ...resolved,
    config: klona(resolved.config),
  }),
});
```

Related to nuxt/nuxt#30853.