### PR TITLE
feat: support `<NAME>_APPNAME` env to override config name

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Resolve configuration from this working directory. The default is `process.cwd()
 
 Configuration base name. The default is `config`.
 
+It can be overridden at runtime with a `<NAME>_APPNAME` environment variable (the uppercased `name`), similar to Neovim's [`NVIM_APPNAME`](https://neovim.io/doc/user/starting.html#%24NVIM_APPNAME). This allows loading an alternative config set without changing code (for example `MYAPP_APPNAME=myapp-next`).
+
 ### `configFile`
 
 Configuration file name without extension. Default is generated from `name` (f.e., if `name` is `foo`, the config file will be => `foo.config`).

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -58,10 +58,13 @@ export async function loadConfig<
   // Normalize options
   options.cwd = resolve(process.cwd(), options.cwd || ".");
   options.name = options.name || "config";
+  // Allow overriding the config name via a `<NAME>_APPNAME` env variable (similar to Neovim's `NVIM_APPNAME`)
+  const configName =
+    process.env[`${options.name.toUpperCase().replace(/\W/g, "_")}_APPNAME`] || options.name;
   options.envName = options.envName ?? process.env.NODE_ENV;
   options.configFile =
-    options.configFile ?? (options.name === "config" ? "config" : `${options.name}.config`);
-  options.rcFile = options.rcFile ?? `.${options.name}rc`;
+    options.configFile ?? (configName === "config" ? "config" : `${configName}.config`);
+  options.rcFile = options.rcFile ?? `.${configName}rc`;
   if (options.extend !== false) {
     options.extend = {
       extendKey: "extends",
@@ -135,7 +138,7 @@ export async function loadConfig<
     const keys = (
       Array.isArray(options.packageJson)
         ? options.packageJson
-        : [typeof options.packageJson === "string" ? options.packageJson : options.name]
+        : [typeof options.packageJson === "string" ? options.packageJson : configName]
     ).filter((t) => t && typeof t === "string");
     const pkgJsonFile = await readPackageJSON(options.cwd).catch(() => {});
     const values = keys.map((key) => pkgJsonFile?.[key]);

--- a/test/fixture/appname/custom.config.json
+++ b/test/fixture/appname/custom.config.json
@@ -1,0 +1,3 @@
+{
+  "appName": "custom"
+}

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -398,6 +398,25 @@ describe("loader", () => {
     expect(config).toMatchObject({ baseKey: true, multiDotLayer: true });
   });
 
+  it("overrides name via `<NAME>_APPNAME` env variable (#299)", async () => {
+    const prevAppName = process.env.TEST_APPNAME;
+    process.env.TEST_APPNAME = "custom";
+    try {
+      const { config, configFile } = await loadConfig({
+        name: "test",
+        cwd: r("./fixture/appname"),
+      });
+      expect(config).toMatchObject({ appName: "custom" });
+      expect(configFile).toContain("custom.config");
+    } finally {
+      if (prevAppName === undefined) {
+        delete process.env.TEST_APPNAME;
+      } else {
+        process.env.TEST_APPNAME = prevAppName;
+      }
+    }
+  });
+
   it("falls back to jiti when native import fails", async () => {
     // Fixture uses a TS enum, which Node's strip-only mode rejects, so the
     // native dynamic import() throws and c12 must fall back to jiti.


### PR DESCRIPTION
Adds support for a `<NAME>_APPNAME` environment variable (the uppercased `name`) that overrides the config name used to resolve config and RC files at runtime, following the same idea as Neovim's `NVIM_APPNAME`. This lets operators point c12 at an alternative config set (e.g. `MYAPP_APPNAME=myapp-next`) without changing any code.

Fixes #299


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime support for overriding the application configuration name via an environment variable (`<NAME>_APPNAME`).
  * The override now affects both configuration selection and package.json-based configuration lookups.

* **Documentation**
  * Clarified the environment variable format and added an example showing how to load an alternate config set.

* **Tests**
  * Added a test to verify the override updates the loaded config name and selects the expected configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->