### PR TITLE
perf: load `pkg-types` only when it is needed

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -6,7 +6,6 @@ import { resolve, extname, dirname, basename, join, normalize } from "pathe";
 import { resolveModulePath } from "exsolve";
 import * as rc9 from "rc9";
 import { defu } from "defu";
-import { findWorkspaceDir, readPackageJSON } from "pkg-types";
 import { setupDotenv } from "./dotenv.ts";
 
 import type {
@@ -120,6 +119,7 @@ export async function loadConfig<
     rcSources.push(rc9.read({ name: options.rcFile, dir: options.cwd }));
     if (options.globalRc) {
       // 2. workspace
+      const { findWorkspaceDir } = await import("pkg-types");
       const workspaceDir = await findWorkspaceDir(options.cwd).catch(() => {});
       if (workspaceDir) {
         rcSources.push(rc9.read({ name: options.rcFile, dir: workspaceDir }));
@@ -137,6 +137,7 @@ export async function loadConfig<
         ? options.packageJson
         : [typeof options.packageJson === "string" ? options.packageJson : options.name]
     ).filter((t) => t && typeof t === "string");
+    const { readPackageJSON } = await import("pkg-types");
     const pkgJsonFile = await readPackageJSON(options.cwd).catch(() => {});
     const values = keys.map((key) => pkgJsonFile?.[key]);
     rawConfigs.packageJson = _merger({} as T, ...values);


### PR DESCRIPTION
resolves #329

`pkg-types` is imported at the top of `src/loader.ts`, but both of its uses sit behind options that default to off:
- `findWorkspaceDir` — only under `if (options.globalRc)`
- `readPackageJSON` — only under `if (options.packageJson)`

It costs more than itself, though: `pkg-types` statically imports the `confbox` barrel, which pulls all five parsers plus their vendored libraries — json5, jsonc, yaml, toml, ini, and with them js-yaml, smol-toml, jsonc-parser and detect-indent. That quietly undoes the per-extension `import("confbox/json5")` laziness a few lines below in the same file.

Moving the import to its two call sites, measured on `loadConfig()` against a directory with no config file (the path every consumer pays regardless):

| | before | after
|---|---|---|
| modules loaded | 34 | 18
| third-party packages | 7 | 5
| `import("c12")` | 11.3 ms | 8.2 ms

Packages dropped from the load path: `confbox`, `pkg-types`. Anyone opting into `globalRc` or `packageJson` pays exactly what they did before, one tick later.

`rc9` is deliberately left static: `options.rcFile` defaults to `.${options.name}rc`, so it is read on every load.

Existing tests cover both branches (`packageJson: ["c12", "c12-alt"]` and `globalRc: true` in `test/loader.test.ts`), and pass unchanged along with lint and tsgo.

Follows the same direction as #295 (optional jiti loader) and #296 (native dotenv parser).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading reliability by adjusting how workspace and package information is loaded.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->