### PR TITLE
feat: support configFile: false option to skip config file loading

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -76,7 +76,7 @@ export async function loadConfig<
   const r: ResolvedConfig<T, MT> = {
     config: {} as any,
     cwd: options.cwd,
-    configFile: resolve(options.cwd, options.configFile),
+    configFile: options.configFile ? resolve(options.cwd, options.configFile) : undefined,
     layers: [],
     _configFile: undefined,
   };
@@ -102,15 +102,17 @@ export async function loadConfig<
   }
 
   // Load main config file
-  const _mainConfig = await resolveConfig(".", options);
-  if (_mainConfig.configFile) {
-    rawConfigs.main = _mainConfig.config;
-    r.configFile = _mainConfig.configFile;
-    r._configFile = _mainConfig._configFile;
-  }
+  if (options.configFile !== false) {
+    const _mainConfig = await resolveConfig(".", options);
+    if (_mainConfig.configFile) {
+      rawConfigs.main = _mainConfig.config;
+      r.configFile = _mainConfig.configFile;
+      r._configFile = _mainConfig._configFile;
+    }
 
-  if (_mainConfig.meta) {
-    r.meta = _mainConfig.meta;
+    if (_mainConfig.meta) {
+      r.meta = _mainConfig.meta;
+    }
   }
 
   // Load rc files
@@ -356,7 +358,7 @@ async function resolveConfig<
   const isDir = _isDirectory(resolvedPath) ?? (!ext || ext === basename(source)); /* #71 */
   const cwd = resolve(options.cwd!, isDir ? source : dirname(source));
   if (isDir) {
-    source = options.configFile!;
+    source = (options.configFile || options.name || "config") as string;
   }
   const res: ResolvedConfig<T, MT> = {
     config: undefined as unknown as T,

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,7 +105,7 @@ export interface LoadConfigOptions<
   name?: string;
   cwd?: string;
 
-  configFile?: string;
+  configFile?: false | string;
 
   rcFile?: false | string;
   globalRc?: boolean;

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -59,17 +59,25 @@ export async function watchConfig<
 
   const configName = options.name || "config";
   const configFileName =
-    options.configFile ?? (options.name === "config" ? "config" : `${options.name}.config`);
+    typeof options.configFile === "string"
+      ? options.configFile
+      : options.configFile === false
+        ? ""
+        : options.name === "config"
+          ? "config"
+          : `${options.name}.config`;
   const watchingFiles = [
     ...new Set(
       (config.layers || [])
         .filter((l) => l.cwd)
         .flatMap((l) => [
-          ...SUPPORTED_EXTENSIONS.flatMap((ext) => [
-            resolve(l.cwd!, configFileName + ext),
-            resolve(l.cwd!, ".config", configFileName + ext),
-            resolve(l.cwd!, ".config", configFileName.replace(/\.config$/, "") + ext),
-          ]),
+          ...(configFileName
+            ? SUPPORTED_EXTENSIONS.flatMap((ext) => [
+                resolve(l.cwd!, configFileName + ext),
+                resolve(l.cwd!, ".config", configFileName + ext),
+                resolve(l.cwd!, ".config", configFileName.replace(/\.config$/, "") + ext),
+              ])
+            : []),
           l.source && resolve(l.cwd!, l.source),
           // TODO: Support watching rc from home and workspace
           options.rcFile &&

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -354,6 +354,23 @@ describe("loader", () => {
     ).rejects.toThrowError("Required config (CUSTOM) cannot be resolved.");
   });
 
+  it("support configFile: false to skip loading config file", async () => {
+    const { config, configFile } = await loadConfig({
+      cwd: r("./fixture"),
+      configFile: false,
+      rcFile: false,
+      dotenv: false,
+      packageJson: false,
+      defaults: {
+        defaultKey: "defaultVal",
+      },
+    });
+    expect(configFile).toBeUndefined();
+    expect(config).toEqual({
+      defaultKey: "defaultVal",
+    });
+  });
+
   it("loads arrays exported from config without merging", async () => {
     const loaded = await loadConfig({
       name: "test",

--- a/test/types.ts
+++ b/test/types.ts
@@ -29,4 +29,8 @@ async function main() {
   const config = await loadConfig<MyConfig, MyMeta>({});
   expectTypeOf(config.config!.foo).toEqualTypeOf<string>();
   expectTypeOf(config.meta!.metaFoo).toEqualTypeOf<string>();
+
+  await loadConfig<MyConfig, MyMeta>({
+    configFile: false,
+  });
 }


### PR DESCRIPTION
## Problem

While disabling the config file via `configFile: false` is documented and useful when loading purely from defaults, RC files, or environment overrides, `configFile` was only typed as `string` in `LoadConfigOptions` and `loadConfig` unconditionally attempted to resolve main configuration files even when `configFile: false` was provided.

## Solution

- Updated `configFile` type in `LoadConfigOptions` to `false | string`.
- In `loadConfig`, skipped resolving the main config file when `options.configFile === false`.
- In `watchConfig`, handled `options.configFile === false` to avoid watching unneeded default config file paths.

## Testing

- Added type assertions in `test/types.ts` confirming `configFile: false` compiles with `tsgo --noEmit`.
- Added unit tests in `test/loader.test.ts` verifying that `configFile: false` skips config file resolution and correctly uses provided defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to explicitly disable configuration-file loading.
  - Configuration loading can now rely solely on defaults and other explicitly enabled sources.
  - Configuration watching can also be disabled when file loading is turned off.

- **Bug Fixes**
  - Prevented disabled configuration files from being reported or watched.
  - Improved default configuration naming when no file path is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->